### PR TITLE
Add appveyor.yml for continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,170 @@
+# Notes:
+#   - Minimal appveyor.yml file is an empty file. All sections are optional.
+#   - Indent each level of configuration with 2 spaces. Do not use tabs!
+#   - All section names are case-sensitive.
+#   - Section names should be unique on each level.
+
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+# NOTE: version is now generated in "before_build:"
+#version: x.y.z-{build}
+
+# you can use {branch} name in version format too
+# version: 1.0.{build}-{branch}
+
+# branches to build
+#branches:
+  # whitelist
+  # Setting this prevents PRs from being auto-built
+  # only:
+  #  - master
+
+# Do not build on tags (GitHub and BitBucket)
+skip_tags: true
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# Build worker image (VM template)
+image: Visual Studio 2015
+
+# scripts that are called at very beginning, before repo cloning
+init:
+  - git config --global core.autocrlf input
+
+# build cache to preserve files/folders between builds
+cache:
+  - '%LocalAppData%\NuGet\Cache'
+
+# Automatically register private account and/or project AppVeyor NuGet feeds.
+nuget:
+  account_feed: true
+  project_feed: true
+  disable_publish_on_pr: true     # disable publishing of .nupkg artifacts to
+                                  # account/project feeds for pull request builds
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+# build Configuration, i.e. Debug, Release, etc.
+configuration: Release
+
+# scripts to run before build
+before_build:
+  - ps: $xml = [xml] (Get-Content CurrentVersion.props); $major = $xml.Project.PropertyGroup.MajorVersion; $minor = $xml.Project.PropertyGroup.MinorVersion; $micro = $xml.Project.PropertyGroup.MicroVersion; $serial = $xml.Project.PropertyGroup.ReleaseSerial; Update-AppveyorBuild -Version "$($major).$($minor).$($micro).$($serial)-$($env:APPVEYOR_BUILD_NUMBER)".replace(" ","")
+
+# scripts to run *after* solution is built and *before* automatic packaging occurs (web apps, NuGet packages, Azure Cloud Services)
+before_package:
+
+# scripts to run after build
+after_build:
+
+# to run your custom scripts instead of automatic MSBuild
+build_script:
+  - msbuild Dlr.sln /t:Build /p:BaseConfiguration=%CONFIGURATION% /verbosity:minimal /nologo
+
+# to disable automatic builds
+#build: off
+
+# to run your custom scripts instead of automatic tests
+test_script:
+  - '%APPVEYOR_BUILD_FOLDER%/bin/%CONFIGURATION%/TestInternalDLR.exe'
+  #- make test
+  #- Test\test-ipy-tc.cmd /category:Languages\IronPython\IronPython\2.X
+
+# to run custom scripts after tests
+#after_test:
+  # upload results to AppVeyor
+  # NOTE: our test runner returns an exit code with number of failures
+  # AppVeyor misinterprets that and does not upload test results
+  # Workaround in that case is to add to "on_failure:" and "on_success:"
+  # to force an upload
+  #- ps: $wc = New-Object 'System.Net.WebClient'; $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\Test\TestResult.xml))
+
+#---------------------------------#
+#      artifacts configuration    #
+#---------------------------------#
+
+#artifacts:
+
+#  # pushing a single file
+#  - path: test.zip
+
+#  # pushing entire folder as a zip archive
+#  - path: logs
+
+#  # pushing all *.nupkg files in build directory recursively
+#  - path: '**\*.nupkg'
+
+
+#---------------------------------#
+#     deployment configuration    #
+#---------------------------------#
+
+# providers: Local, FTP, WebDeploy, AzureCS, AzureBlob, S3, NuGet, Environment
+# provider names are case-sensitive!
+#deploy:
+
+#    # Deploying to NuGet feed
+#  - provider: NuGet
+#    server: https://my.nuget.server/feed
+#    api_key:
+#      secure: FYWX6NfjZIVw==
+#    skip_symbols: false
+#    symbol_server: https://your.symbol.server/feed
+#    artifact: MyPackage.nupkg
+
+#    # Deploy to GitHub Releases
+#  - provider: GitHub
+#    artifact: /.*\.nupkg/           # upload all NuGet packages to release assets
+#    draft: false
+#    prerelease: false
+#    on:
+#      branch: master                # release from master branch only
+#      appveyor_repo_tag: true       # deploy on tag push only
+
+#        global handlers          #
+#---------------------------------#
+
+# on successful build
+on_success:
+  # upload test results to AppVeyor
+  #- ps: $wc = New-Object 'System.Net.WebClient'; $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\Test\TestResult.xml))
+
+# on build failure
+on_failure:
+  # upload test results to AppVeyor
+  #- ps: $wc = New-Object 'System.Net.WebClient'; $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\Test\TestResult.xml))
+
+# after build failure or success
+#on_finish:
+#  - do something
+  
+#---------------------------------#
+#         notifications           #
+#---------------------------------#
+  
+notifications:
+
+  # Email
+  - provider: Email
+    to:
+      - slide.o.mix@gmail.com
+      - ticotimo@gmail.com
+    # use defaults for now
+    #subject: 'Build {{status}}'                  # optional
+    #message: "{{message}}, {{commitId}}, ..."    # optional
+    on_build_status_changed: true
+
+  # Gitter
+  - provider: Webhook
+    url: https://webhooks.gitter.im/e/9fdb5c75f38c850816f8
+    #headers: ? message payload? how to differentiate projects?
+    on_build_success: true
+    on_build_failure: true
+    on_build_status_changed: true


### PR DESCRIPTION
Initial attempt builds and runs the TestInternalDLR.exe. No ```nunit``` style results are written, so no publication of results to the ```Tests``` tab. But, better to have some CI than none at all.