### PR TITLE
Remove usage of TypeInfo

### DIFF
--- a/Build/net45.props
+++ b/Build/net45.props
@@ -56,7 +56,6 @@
     <Features>$(Features);FEATURE_ICLONEABLE</Features>
     <Features>$(Features);FEATURE_ANSICP</Features>
     <Features>$(Features);FEATURE_ASYNC</Features>
-    <Features>$(Features);FEATURE_TYPE_INFO</Features>
     <Features>$(Features);FEATURE_DYNAMIC_EXPRESSION_VISITOR</Features>
     <Features Condition=" '$(Mono)' != 'True' ">$(Features);FEATURE_ASSEMBLYBUILDER_DEFINEDYNAMICASSEMBLY</Features>
     <Features>$(Features);FEATURE_READONLY_DICTIONARY</Features>

--- a/Build/netcoreapp2.0.props
+++ b/Build/netcoreapp2.0.props
@@ -44,7 +44,6 @@
     <Features>$(Features);FEATURE_SYNC_SOCKETS</Features>
     <Features>$(Features);FEATURE_THREAD</Features>
     <Features>$(Features);FEATURE_TYPE_EQUIVALENCE</Features>
-    <Features>$(Features);FEATURE_TYPE_INFO</Features>
     <Features>$(Features);FEATURE_TYPECONVERTER</Features>
     <Features>$(Features);FEATURE_VARIANCE</Features>
     <Features>$(Features);FEATURE_WARNING_EXCEPTION</Features>

--- a/Src/Microsoft.Dynamic/Actions/DefaultBinder.Operations.cs
+++ b/Src/Microsoft.Dynamic/Actions/DefaultBinder.Operations.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Scripting.Actions {
         public DynamicMetaObject GetDocumentation(DynamicMetaObject target) {
             BindingRestrictions restrictions = BindingRestrictions.GetTypeRestriction(target.Expression, target.LimitType);
 
-            DocumentationAttribute attr = target.LimitType.GetTypeInfo().GetCustomAttribute<DocumentationAttribute>();
+            DocumentationAttribute attr = target.LimitType.GetCustomAttribute<DocumentationAttribute>();
             string documentation = (attr != null) ? attr.Documentation : String.Empty;
 
             return new DynamicMetaObject(

--- a/Src/Microsoft.Dynamic/Actions/MemberTracker.cs
+++ b/Src/Microsoft.Dynamic/Actions/MemberTracker.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Scripting.Actions {
                 } else if ((evnt = member as EventInfo) != null) {
                     res = new EventTracker(evnt);
                 } else if ((type = member as TypeInfo) != null) {
-                    res = new NestedTypeTracker(type.AsType());
+                    res = new NestedTypeTracker(type);
                 } else {
                     throw Error.UnknownMemberType(member);
                 }

--- a/Src/Microsoft.Dynamic/Actions/NamespaceTracker.cs
+++ b/Src/Microsoft.Dynamic/Actions/NamespaceTracker.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Scripting.Actions {
                     if (existingTypeEntity == null) {
                         // Replace the existing namespace or module with the new type
                         Debug.Assert(existingValue is NamespaceTracker);
-                        _dict[normalizedTypeName] = MemberTracker.FromMemberInfo(newType.GetTypeInfo());
+                        _dict[normalizedTypeName] = MemberTracker.FromMemberInfo(newType);
                     } else {
                         // Unify the new type with the existing type
                         _dict[normalizedTypeName] = TypeGroup.UpdateTypeEntity(existingTypeEntity, TypeTracker.GetTypeTracker(newType));

--- a/Src/Microsoft.Dynamic/Ast/ConstantExpression.cs
+++ b/Src/Microsoft.Dynamic/Ast/ConstantExpression.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Scripting.Ast {
                 return Expression.Constant(value, typeof(PropertyInfo));
             } else {
                 Type t = value.GetType();
-                if (!t.GetTypeInfo().IsEnum) {
+                if (!t.IsEnum) {
                     switch (t.GetTypeCode()) {
                         case TypeCode.Boolean:
                             return (bool)value ? TrueLiteral : FalseLiteral;

--- a/Src/Microsoft.Dynamic/Generation/CompilerHelpers.cs
+++ b/Src/Microsoft.Dynamic/Generation/CompilerHelpers.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Scripting.Generation {
         }
 
         public static bool IsProtected(this Type type) {
-            return type.GetTypeInfo().IsNestedFamily || type.GetTypeInfo().IsNestedFamORAssem;
+            return type.IsNestedFamily || type.IsNestedFamORAssem;
         }
 
         public static Type GetVisibleType(object value) {
@@ -460,7 +460,7 @@ namespace Microsoft.Scripting.Generation {
         /// </summary>
         public static Expression GetTryConvertReturnValue(Type type) {
             Expression res;
-            var info = type.GetTypeInfo();
+            var info = type;
             if (info.IsInterface || info.IsClass || (info.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))) {
                 res = AstUtils.Constant(null, type);
             } else {

--- a/Src/Microsoft.Dynamic/Generation/Snippets.cs
+++ b/Src/Microsoft.Dynamic/Generation/Snippets.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Scripting.Generation {
             //    inner ring assemblies have dependency on outer ring assemlies via generated IL.
             // 3) Verify inner ring assemblies.
             // 4) Verify outer ring assemblies.
-            Assembly core = typeof(Expression).GetTypeInfo().Assembly;
+            Assembly core = typeof(Expression).Assembly;
             Type assemblyGen = core.GetType(typeof(Expression).Namespace + ".Compiler.AssemblyGen");
             //The type may not exist.
             string[] coreAssemblyLocations = null;

--- a/Src/Microsoft.Dynamic/Runtime/AssemblyTypeNames.cs
+++ b/Src/Microsoft.Dynamic/Runtime/AssemblyTypeNames.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Scripting.Runtime {
         public static IEnumerable<TypeName> GetTypeNames(Assembly assem, bool includePrivateTypes) {
             return from t in ReflectionUtils.GetAllTypesFromAssembly(assem, includePrivateTypes)
                    where !t.IsNested
-                   select new TypeName(t.AsType());
+                   select new TypeName(t);
         }
 
         static IEnumerable<TypeName> GetTypeNames(string[] namespaces, string[][] types) {

--- a/Src/Microsoft.Dynamic/Runtime/ExtensionTypeAttribute.cs
+++ b/Src/Microsoft.Dynamic/Runtime/ExtensionTypeAttribute.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Scripting.Runtime {
             if (extends == null) {
                 throw new ArgumentNullException(nameof(extends));
             }
-            if (extensionType != null && !extensionType.GetTypeInfo().IsPublic && !extensionType.GetTypeInfo().IsNestedPublic) {
+            if (extensionType != null && !extensionType.IsPublic && !extensionType.IsNestedPublic) {
                 throw Error.ExtensionMustBePublic(extensionType.FullName);
             }
 

--- a/Src/Microsoft.Dynamic/Utils/AssemblyQualifiedTypeName.cs
+++ b/Src/Microsoft.Dynamic/Utils/AssemblyQualifiedTypeName.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Scripting.Utils {
 
         public AssemblyQualifiedTypeName(Type type) {
             TypeName = type.FullName;
-            AssemblyName = type.GetTypeInfo().Assembly.GetName();
+            AssemblyName = type.Assembly.GetName();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]

--- a/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
+++ b/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
@@ -534,11 +534,11 @@ namespace Microsoft.Scripting.Utils {
         #endregion
 
         public static Type[] GetGenericTypeArguments(this Type type) {
-            return type.IsGenericType && !type.IsGenericTypeDefinition ? type.GetTypeInfo().GetGenericArguments() : null;
+            return type.IsGenericType && !type.IsGenericTypeDefinition ? type.GetGenericArguments() : null;
         }
 
         public static Type[] GetGenericTypeParameters(this Type type) {
-            return type.IsGenericTypeDefinition ? type.GetTypeInfo().GetGenericArguments() : null;
+            return type.IsGenericTypeDefinition ? type.GetGenericArguments() : null;
         }
 
         public static IEnumerable<Module> GetModules(this Assembly assembly) {
@@ -586,59 +586,59 @@ namespace Microsoft.Scripting.Utils {
 #endif
 
         public static bool ContainsGenericParameters(this Type type) {
-            return type.GetTypeInfo().ContainsGenericParameters;
+            return type.ContainsGenericParameters;
         }
 
         public static bool IsInterface(this Type type) {
-            return type.GetTypeInfo().IsInterface;
+            return type.IsInterface;
         }
 
         public static bool IsClass(this Type type) {
-            return type.GetTypeInfo().IsClass;
+            return type.IsClass;
         }
 
         public static bool IsGenericType(this Type type) {
-            return type.GetTypeInfo().IsGenericType;
+            return type.IsGenericType;
         }
 
         public static bool IsGenericTypeDefinition(this Type type) {
-            return type.GetTypeInfo().IsGenericTypeDefinition;
+            return type.IsGenericTypeDefinition;
         }
 
         public static bool IsSealed(this Type type) {
-            return type.GetTypeInfo().IsSealed;
+            return type.IsSealed;
         }
 
         public static bool IsAbstract(this Type type) {
-            return type.GetTypeInfo().IsAbstract;
+            return type.IsAbstract;
         }
 
         public static bool IsPublic(this Type type) {
-            return type.GetTypeInfo().IsPublic;
+            return type.IsPublic;
         }
 
         public static bool IsVisible(this Type type) {
-            return type.GetTypeInfo().IsVisible;
+            return type.IsVisible;
         }
         
         public static Type GetBaseType(this Type type) {
-            return type.GetTypeInfo().BaseType;
+            return type.BaseType;
         }
 
         public static bool IsValueType(this Type type) {
-            return type.GetTypeInfo().IsValueType;
+            return type.IsValueType;
         }
 
         public static bool IsEnum(this Type type) {
-            return type.GetTypeInfo().IsEnum;
+            return type.IsEnum;
         }
 
         public static bool IsPrimitive(this Type type) {
-            return type.GetTypeInfo().IsPrimitive;
+            return type.IsPrimitive;
         }
 
         public static GenericParameterAttributes GetGenericParameterAttributes(this Type type) {
-            return type.GetTypeInfo().GenericParameterAttributes;
+            return type.GenericParameterAttributes;
         }
         
         public static Type[] EmptyTypes = new Type[0];
@@ -1059,7 +1059,7 @@ namespace Microsoft.Scripting.Utils {
         public static IEnumerable<Type> Ancestors(this Type type) {
             do {
                 yield return type;
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             } while (type != null);
         }
 
@@ -1126,7 +1126,7 @@ namespace Microsoft.Scripting.Utils {
 
         public static MethodBuilder DefineMethodOverride(TypeBuilder tb, MethodAttributes extra, MethodInfo decl) {
             MethodAttributes finalAttrs = (decl.Attributes & ~MethodAttributesToEraseInOveride) | extra;
-            if (!decl.DeclaringType.GetTypeInfo().IsInterface) {
+            if (!decl.DeclaringType.IsInterface) {
                 finalAttrs &= ~MethodAttributes.NewSlot;
             }
 
@@ -1253,7 +1253,7 @@ namespace Microsoft.Scripting.Utils {
                         type.IsSealed &&
                         type.IsDefined(ea, false)) {
 
-                        foreach (MethodInfo method in type.AsType().GetDeclaredMethods()) {
+                        foreach (MethodInfo method in type.GetDeclaredMethods()) {
                             if (method.IsPublic && method.IsStatic && method.IsDefined(ea, false)) {
                                 yield return method;
                             }
@@ -1518,7 +1518,7 @@ namespace Microsoft.Scripting.Utils {
                 return true;
             }
 #endif
-            if (!_extendedType.GetTypeInfo().ContainsGenericParameters) {
+            if (!_extendedType.ContainsGenericParameters) {
                 return false;
             }
 

--- a/Src/Microsoft.Scripting/Hosting/ScriptRuntime.cs
+++ b/Src/Microsoft.Scripting/Hosting/ScriptRuntime.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Scripting.Hosting {
 
             object noDefaultRefs;
             if (!setup.Options.TryGetValue("NoDefaultReferences", out noDefaultRefs) || Convert.ToBoolean(noDefaultRefs) == false) {
-                LoadAssembly(typeof(string).GetTypeInfo().Assembly);
-                LoadAssembly(typeof(Debug).GetTypeInfo().Assembly);
+                LoadAssembly(typeof(string).Assembly);
+                LoadAssembly(typeof(Debug).Assembly);
             }
         }
 

--- a/Src/Microsoft.Scripting/Hosting/ScriptRuntimeSetup.cs
+++ b/Src/Microsoft.Scripting/Hosting/ScriptRuntimeSetup.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Scripting.Hosting {
             get { return _hostType; }
             set {
                 ContractUtils.RequiresNotNull(value, "value");
-                ContractUtils.Requires(typeof(ScriptHost).GetTypeInfo().IsAssignableFrom(value.GetTypeInfo()), "value", "Must be ScriptHost or a derived type of ScriptHost");
+                ContractUtils.Requires(typeof(ScriptHost).IsAssignableFrom(value), "value", "Must be ScriptHost or a derived type of ScriptHost");
                 CheckFrozen();
                 _hostType = value;
             }

--- a/Src/Microsoft.Scripting/Runtime/DlrConfiguration.cs
+++ b/Src/Microsoft.Scripting/Runtime/DlrConfiguration.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Scripting.Runtime {
                     ));
                 }
 
-                if (!type.GetTypeInfo().IsSubclassOf(typeof(LanguageContext))) {
+                if (!type.IsSubclassOf(typeof(LanguageContext))) {
                     throw new InvalidOperationException(
                         $"Failed to load language '{_displayName}': type '{type}' is not a valid language provider because it does not inherit from LanguageContext"); 
                 }

--- a/Src/Microsoft.Scripting/Runtime/DynamicOperations.cs
+++ b/Src/Microsoft.Scripting/Runtime/DynamicOperations.cs
@@ -231,14 +231,14 @@ namespace Microsoft.Scripting.Runtime {
         /// depending on what the langauge prefers.
         /// </summary>
         public object ConvertTo(object obj, Type type) {
-            if (type.GetTypeInfo().IsInterface || type.GetTypeInfo().IsClass) {
+            if (type.IsInterface || type.IsClass) {
                 CallSite<Func<CallSite, object, object>> site;
                 site = GetOrCreateSite<object, object>(_lc.CreateConvertBinder(type, null));
                 return site.Target(site, obj);
             }
 
             // TODO: We should probably cache these instead of using reflection all the time.
-            foreach (MethodInfo mi in typeof(DynamicOperations).GetTypeInfo().GetDeclaredMethods("ConvertTo")) {
+            foreach (MethodInfo mi in typeof(DynamicOperations).GetDeclaredMethods("ConvertTo")) {
                 if (mi.IsGenericMethod) {
                     try {
                         return mi.MakeGenericMethod(type).Invoke(this, new object[] { obj });

--- a/Src/Microsoft.Scripting/Runtime/LanguageContext.cs
+++ b/Src/Microsoft.Scripting/Runtime/LanguageContext.cs
@@ -397,7 +397,7 @@ namespace Microsoft.Scripting.Runtime {
             }
 
             public override DynamicMetaObject FallbackConvert(DynamicMetaObject self, DynamicMetaObject errorSuggestion) {
-                if (Type.GetTypeInfo().IsAssignableFrom(self.LimitType.GetTypeInfo())) {
+                if (Type.IsAssignableFrom(self.LimitType)) {
                     return new DynamicMetaObject(
                         Expression.Convert(self.Expression, Type),
                         BindingRestrictions.GetTypeRestriction(self.Expression, self.LimitType)
@@ -591,7 +591,7 @@ namespace Microsoft.Scripting.Runtime {
                 return false;
             }
 
-            return typeof(Delegate).GetTypeInfo().IsAssignableFrom(obj.GetType().GetTypeInfo());
+            return typeof(Delegate).IsAssignableFrom(obj.GetType());
         }
 
         #endregion

--- a/Src/Microsoft.Scripting/Stubs.cs
+++ b/Src/Microsoft.Scripting/Stubs.cs
@@ -55,24 +55,7 @@ namespace System.IO {
         Inheritable = 16
     }
 }
-#else
-namespace System {
-    public static class TypeExtensions {
-#if !FEATURE_TYPE_INFO
-        public static Type GetTypeInfo(this Type type) {
-            return type;
-        }
 
-        public static InterfaceMapping GetRuntimeInterfaceMap(this Type type, Type iface) {
-            return type.GetInterfaceMap(iface);
-        }
-#endif
-
-        public static Type AsType(this Type type) {
-            return type;
-        }
-    }
-}
 #endif
 
 #if !FEATURE_SERIALIZATION

--- a/Src/Microsoft.Scripting/Utils/AssemblyQualifiedTypeName.cs
+++ b/Src/Microsoft.Scripting/Utils/AssemblyQualifiedTypeName.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Scripting.Utils {
 
         public AssemblyQualifiedTypeName(Type type) {
             TypeName = type.FullName;
-            AssemblyName = type.GetTypeInfo().Assembly.GetName();
+            AssemblyName = type.Assembly.GetName();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]


### PR DESCRIPTION
This gets rid of `TypeInfo` related stuff.

The only reason to keep `TypeInfo` would be to support .NET Core 1.0 or Win 8/10. To target Windows UWP we would have to restrict ourselves to the Fall Creators Update (October 2017) or later which supports .NET Standard 2.0 (and so `TypeInfo` would no longer be required). Since we haven't officially supported any of those in the past I see no reason to keep the code...
