### PR TITLE
Re-add VB.NET Builds

### DIFF
--- a/Tests/ClrAssembly/ClrAssembly.csproj
+++ b/Tests/ClrAssembly/ClrAssembly.csproj
@@ -48,7 +48,7 @@
     <Csc TargetType="Library" References="@(ReferencePath);$(OutputPath)\$(Prefix)typesamples.dll" Sources="%(AreaCSFile.Identity)" OutputAssembly="$(OutputPath)\$(Prefix)%(AreaCSFile.Filename).dll" />
   </Target>
 
-  <Target Name="VBManyArea" Inputs="@(AreaVBFile)" Outputs="$(OutputPath)\$(Prefix)%(Filename).dll" DependsOnTargets="TypeSample" Condition="'$(MSBuildRuntimeType)' != 'Mono'">
+  <Target Name="VBManyArea" Inputs="@(AreaVBFile)" Outputs="$(OutputPath)\$(Prefix)%(Filename).dll" DependsOnTargets="TypeSample">
     <ItemGroup>
       <VbcReferencePath Include="@(ReferencePath)" />
       <VbcReferencePath Include="$(OutputPath)$(Prefix)typesamples.dll" />


### PR DESCRIPTION
Mono now packages the VB.NET compiler from Roslyn, so re-enable the builds.