### PR TITLE
Make all libs support netstandard2.0

### DIFF
--- a/Build/netstandard2.0.props
+++ b/Build/netstandard2.0.props
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IsFullFramework>false</IsFullFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Features>$(Features);FEATURE_APARTMENTSTATE</Features>
+    <Features>$(Features);FEATURE_APPLICATIONEXCEPTION</Features>
+    <Features>$(Features);FEATURE_ASSEMBLY_CODEBASE</Features>
+    <Features>$(Features);FEATURE_ASSEMBLY_LOCATION</Features>
+    <Features>$(Features);FEATURE_ASSEMBLY_RESOLVE</Features>
+    <Features>$(Features);FEATURE_ASSEMBLYBUILDER_DEFINEDYNAMICASSEMBLY</Features>
+    <Features>$(Features);FEATURE_BASIC_CONSOLE</Features>
+    <Features>$(Features);FEATURE_CODEDOM</Features>
+    <Features>$(Features);FEATURE_CONFIGURATION</Features>
+    <Features>$(Features);FEATURE_CUSTOM_TYPE_DESCRIPTOR</Features>
+    <Features>$(Features);FEATURE_DBNULL</Features>
+    <Features>$(Features);FEATURE_DRIVENOTFOUNDEXCEPTION</Features>
+    <Features>$(Features);FEATURE_DYNAMIC_EXPRESSION_VISITOR</Features>
+    <Features>$(Features);FEATURE_ENCODING</Features>
+    <Features>$(Features);FEATURE_EXCEPTION_STATE</Features>
+    <Features>$(Features);FEATURE_FILESYSTEM</Features>
+    <Features>$(Features);FEATURE_FULL_CONSOLE</Features>
+    <Features>$(Features);FEATURE_FULL_CRYPTO</Features>
+    <Features>$(Features);FEATURE_FULL_NET</Features>
+    <Features>$(Features);FEATURE_ICLONEABLE</Features>
+    <Features>$(Features);FEATURE_LCG</Features>
+    <Features>$(Features);FEATURE_LOADWITHPARTIALNAME</Features>
+    <Features>$(Features);FEATURE_METADATA_READER</Features>
+    <Features>$(Features);FEATURE_MMAP</Features>
+    <Features>$(Features);FEATURE_OS_SERVICEPACK</Features>
+    <Features>$(Features);FEATURE_PIPES</Features>
+    <Features>$(Features);FEATURE_PROCESS</Features>
+    <Features>$(Features);FEATURE_REFEMIT</Features>
+    <Features>$(Features);FEATURE_REGISTRY</Features>
+    <Features>$(Features);FEATURE_SECURITY_RULES</Features>
+    <Features>$(Features);FEATURE_SERIALIZATION</Features>
+    <Features>$(Features);FEATURE_SORTKEY</Features>
+    <Features>$(Features);FEATURE_STACK_TRACE</Features>
+    <Features>$(Features);FEATURE_SYNC_SOCKETS</Features>
+    <Features>$(Features);FEATURE_THREAD</Features>
+    <Features>$(Features);FEATURE_TYPE_EQUIVALENCE</Features>
+    <Features>$(Features);FEATURE_TYPECONVERTER</Features>
+    <Features>$(Features);FEATURE_WARNING_EXCEPTION</Features>
+    <Features>$(Features);FEATURE_WIN32EXCEPTION</Features>
+    <Features>$(Features);FEATURE_XMLDOC</Features>
+    <Features Condition=" '$(OS)' != 'Unix' ">$(Features);FEATURE_WINDOWS</Features>
+    <Features Condition=" '$(OS)' == 'Unix' ">$(Features);FEATURE_UNIX</Features>
+  </PropertyGroup>
+</Project>

--- a/Src/Microsoft.Dynamic/Debugging/DelegateHelpers.cs
+++ b/Src/Microsoft.Dynamic/Debugging/DelegateHelpers.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Scripting.Debugging {
             TypeBuilder builder = DefineDelegateType("Delegate_" + Guid.NewGuid().ToString());
             builder.DefineConstructor(CtorAttributes, CallingConventions.Standard, _DelegateCtorSignature).SetImplementationFlags(ImplAttributes);
             builder.DefineMethod("Invoke", InvokeAttributes, returnType, parameters).SetImplementationFlags(ImplAttributes);
-            return builder.CreateType();
+            return builder.CreateTypeInfo().AsType();
         }
 
         private static TypeBuilder DefineDelegateType(string name) {

--- a/Src/Microsoft.Dynamic/Generation/AssemblyGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/AssemblyGen.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Scripting.Generation {
             TypeBuilder builder = DefineType(name, typeof(MulticastDelegate), DelegateAttributes, false);
             builder.DefineConstructor(CtorAttributes, CallingConventions.Standard, _DelegateCtorSignature).SetImplementationFlags(ImplAttributes);
             builder.DefineMethod("Invoke", InvokeAttributes, returnType, parameters).SetImplementationFlags(ImplAttributes);
-            return builder.CreateType();
+            return builder.CreateTypeInfo().AsType();
         }
     }
 }

--- a/Src/Microsoft.Dynamic/Generation/CompilerHelpers.cs
+++ b/Src/Microsoft.Dynamic/Generation/CompilerHelpers.cs
@@ -626,7 +626,7 @@ namespace Microsoft.Scripting.Generation {
             return (T)(object)LightCompile((LambdaExpression)lambda, compilationThreshold);
         }
 
-#if FEATURE_REFEMIT && !NETCOREAPP2_0
+#if FEATURE_REFEMIT && !NETCOREAPP2_0 && !NETSTANDARD2_0
         /// <summary>
         /// Compiles the lambda into a method definition.
         /// </summary>

--- a/Src/Microsoft.Dynamic/Generation/DynamicILGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/DynamicILGen.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Scripting.Generation {
         }
 
         private MethodInfo CreateMethod() {
-            Type t = _tb.CreateType();
+            Type t = _tb.CreateTypeInfo().AsType();
             return t.GetMethod(_mb.Name);
         }
 

--- a/Src/Microsoft.Dynamic/Generation/FieldBuilderExpression.cs
+++ b/Src/Microsoft.Dynamic/Generation/FieldBuilderExpression.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Scripting.Generation {
     public class FieldBuilderExpression : Expression {
         private readonly FieldBuilder _builder;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_0
         private readonly StrongBox<Type> _finishedType;
 
         // Get something which can be updated w/ the final type.
@@ -70,7 +70,7 @@ namespace Microsoft.Scripting.Generation {
 
         private FieldInfo GetFieldInfo() {
             // turn the field builder back into a FieldInfo
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_0
             return _finishedType.Value.GetDeclaredField(_builder.Name);
 #else
             return _builder.DeclaringType.Module.ResolveField(

--- a/Src/Microsoft.Dynamic/Generation/ILGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/ILGen.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Scripting.Generation {
             _ilg.EmitCall(opcode, methodInfo, optionalParameterTypes);
         }
 
-#if !NETCOREAPP2_0
+#if !(NETCOREAPP2_0 || NETSTANDARD2_0)
         /// <summary>
         /// Emits an unmanaged indirect call instruction.
         /// </summary>

--- a/Src/Microsoft.Dynamic/Generation/Snippets.cs
+++ b/Src/Microsoft.Dynamic/Generation/Snippets.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Scripting.Generation {
                 MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, 
                 CallingConventions.Standard, _DelegateCtorSignature).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
             tb.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, returnType, argTypes).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-            return tb.CreateType();
+            return tb.CreateTypeInfo().AsType();
 
         }
 

--- a/Src/Microsoft.Dynamic/Generation/ToDiskRewriter.cs
+++ b/Src/Microsoft.Dynamic/Generation/ToDiskRewriter.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Scripting.Generation {
             // SaveAssemblies mode prevents us from detecting the module as
             // transient. If that option is turned on, always replace delegates
             // that live in another AssemblyBuilder
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_0
             return true; // TODO:
 #else
             var module = delegateType.Module as ModuleBuilder;

--- a/Src/Microsoft.Dynamic/Generation/TypeGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/TypeGen.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Scripting.Generation {
 
         public Type FinishType() {
             _initGen?.Emit(OpCodes.Ret);
-            Type ret = TypeBuilder.CreateType();
+            Type ret = TypeBuilder.CreateTypeInfo().AsType();
             return ret;
         }
 

--- a/Src/Microsoft.Dynamic/Microsoft.Dynamic.csproj
+++ b/Src/Microsoft.Dynamic/Microsoft.Dynamic.csproj
@@ -1,46 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
+    <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
 
-  <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
-    <RootNamespace>Microsoft.Scripting</RootNamespace>
-    <BaseAddress>859832320</BaseAddress>
-    <CodeAnalysisRuleSet>$(AssemblyName).ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+        <RootNamespace>Microsoft.Scripting</RootNamespace>
+        <BaseAddress>859832320</BaseAddress>
+        <CodeAnalysisRuleSet>$(AssemblyName).ruleset</CodeAnalysisRuleSet>
+        <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
-  </ItemGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <DefineConstants>$(DefineConstants.Replace(';FEATURE_FILESYSTEM', ''))</DefineConstants>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Scripting.Metadata\Microsoft.Scripting.Metadata.csproj" Condition=" $(Features.Contains('FEATURE_METADATA_READER')) " />
-    <ProjectReference Include="..\Microsoft.Scripting\Microsoft.Scripting.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="..\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Configuration" Condition=" $(Features.Contains('FEATURE_CONFIGURATION')) " />
-    <Reference Include="System.Runtime.Remoting" Condition=" $(Features.Contains('FEATURE_REMOTING')) " />
-    <Reference Include="System.Xaml" Condition=" $(Features.Contains('FEATURE_WPF')) " />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Microsoft.Scripting.Metadata\Microsoft.Scripting.Metadata.csproj" Condition=" $(Features.Contains('FEATURE_METADATA_READER')) " />
+        <ProjectReference Include="..\Microsoft.Scripting\Microsoft.Scripting.csproj" />
+    </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants.Replace(';FEATURE_FILESYSTEM', ''))</DefineConstants>
-  </PropertyGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+        <Reference Include="System.Configuration" Condition=" $(Features.Contains('FEATURE_CONFIGURATION')) " />
+        <Reference Include="System.Runtime.Remoting" Condition=" $(Features.Contains('FEATURE_REMOTING')) " />
+        <Reference Include="System.Xaml" Condition=" $(Features.Contains('FEATURE_WPF')) " />
+    </ItemGroup>
 
-  <Import Project="$(BeforeTargetFiles)" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    </ItemGroup>
 
-  <Target Name="BeforeBuildStarts" BeforeTargets="BeforeBuild" DependsOnTargets="$(BeforeTargets);GenerateCurrentVersion" />
+    <Import Project="$(BeforeTargetFiles)" />
 
-  <ItemGroup>
-    <!-- if the file does not exist it's not picked up automatically -->
-    <Compile Remove="Properties\CurrentVersion.Generated.cs" />
-    <Compile Include="Properties\CurrentVersion.Generated.cs" />
-  </ItemGroup>
+    <Target Name="BeforeBuildStarts" BeforeTargets="BeforeBuild" DependsOnTargets="$(BeforeTargets);GenerateCurrentVersion" />
 
-  <Import Project="$(AfterTargetFiles)" />
+    <ItemGroup>
+        <!-- if the file does not exist it's not picked up automatically -->
+        <Compile Remove="Properties\CurrentVersion.Generated.cs" />
+        <Compile Include="Properties\CurrentVersion.Generated.cs" />
+    </ItemGroup>
 
-  <Target Name="AfterBuildEnds" AfterTargets="AfterBuild" DependsOnTargets="$(AfterTargets)" />
+    <Import Project="$(AfterTargetFiles)" />
+
+    <Target Name="AfterBuildEnds" AfterTargets="AfterBuild" DependsOnTargets="$(AfterTargets)" />
 
 </Project>

--- a/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
+++ b/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Scripting.Utils {
         //
         // The general algorithm that is used for determining the names in a type and the layout of objects of the type is roughly as follows:
         // - Flatten the inherited names (using the hide by name or hide by name-and-signature rule) ignoring accessibility rules. 
-        // - For each new member that is marked “expect existing slot”, look to see if an exact match on kind (i.e., field or method), 
+        // - For each new member that is marked “expect existing slot? look to see if an exact match on kind (i.e., field or method), 
         //   name, and signature exists and use that slot if it is found, otherwise allocate a new slot. 
         // - After doing this for all new members, add these new member-kind/name/signatures to the list of members of this type 
         // - Finally, remove any inherited names that match the new members based on the hide by name or hide by name-and-signature rules.
@@ -325,7 +325,7 @@ namespace Microsoft.Scripting.Utils {
         // -------------------------
         // [Note: The CLS (see Partition I) refers to instance, virtual, and static properties.  
         // The signature of a property (from the Type column) can be used to distinguish a static property, 
-        // since instance and virtual properties will have the “HASTHIS” bit set in the signature (§23.2.1)
+        // since instance and virtual properties will have the “HASTHIS?bit set in the signature (?3.2.1)
         // while a static property will not.  The distinction between an instance and a virtual property 
         // depends on the signature of the getter and setter methods, which the CLS requires to be either 
         // both virtual or both instance. end note]
@@ -696,7 +696,7 @@ namespace Microsoft.Scripting.Utils {
                 result.Append(' ');
             }
 
-#if FEATURE_REFEMIT && !NETCOREAPP2_0
+#if FEATURE_REFEMIT && !NETCOREAPP2_0 && !NETSTANDARD2_0
             MethodBuilder builder = method as MethodBuilder;
             if (builder != null) {
                 result.Append(builder.Signature);

--- a/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
+++ b/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
@@ -1,4 +1,4 @@
-/* ****************************************************************************
+﻿/* ****************************************************************************
  *
  * Copyright (c) Microsoft Corporation. 
  *
@@ -246,7 +246,7 @@ namespace Microsoft.Scripting.Utils {
                 return true;
             });
         }
-        
+
         #endregion
 
         #region Member Inheritance
@@ -255,7 +255,7 @@ namespace Microsoft.Scripting.Utils {
         // ----------------------------------------------------------------------
         // While hiding applies to all members of a type, overriding deals with object layout and is applicable only to instance fields 
         // and virtual methods. The CTS provides two forms of member overriding, new slot and expect existing slot. A member of a derived 
-        // type that is marked as a new slot will always get a new slot in the object�s layout, guaranteeing that the base field or method 
+        // type that is marked as a new slot will always get a new slot in the object抯 layout, guaranteeing that the base field or method 
         // is available in the object by using a qualified reference that combines the name of the base type with the name of the member 
         // and its type or signature. A member of a derived type that is marked as expect existing slot will re-use (i.e., share or override) 
         // a slot that corresponds to a member of the same kind (field or method), name, and type if one already exists from the base type; 
@@ -263,11 +263,11 @@ namespace Microsoft.Scripting.Utils {
         //
         // The general algorithm that is used for determining the names in a type and the layout of objects of the type is roughly as follows:
         // - Flatten the inherited names (using the hide by name or hide by name-and-signature rule) ignoring accessibility rules. 
-        // - For each new member that is marked �expect existing slot? look to see if an exact match on kind (i.e., field or method), 
+        // - For each new member that is marked expect existing slot, look to see if an exact match on kind (i.e., field or method), 
         //   name, and signature exists and use that slot if it is found, otherwise allocate a new slot. 
         // - After doing this for all new members, add these new member-kind/name/signatures to the list of members of this type 
         // - Finally, remove any inherited names that match the new members based on the hide by name or hide by name-and-signature rules.
-        
+
         // NOTE: Following GetXxx only implement overriding, not hiding specified by hide-by-name or hide-by-name-and-signature flags.
 
         public static IEnumerable<MethodInfo> GetInheritedMethods(this Type type, string name = null, bool flattenHierarchy = false) {
@@ -325,7 +325,7 @@ namespace Microsoft.Scripting.Utils {
         // -------------------------
         // [Note: The CLS (see Partition I) refers to instance, virtual, and static properties.  
         // The signature of a property (from the Type column) can be used to distinguish a static property, 
-        // since instance and virtual properties will have the �HASTHIS?bit set in the signature (?3.2.1)
+        // since instance and virtual properties will have the HASTHIS bit set in the signature (§23.2.1)
         // while a static property will not.  The distinction between an instance and a virtual property 
         // depends on the signature of the getter and setter methods, which the CLS requires to be either 
         // both virtual or both instance. end note]

--- a/Src/Microsoft.Scripting.Metadata/Microsoft.Scripting.Metadata.csproj
+++ b/Src/Microsoft.Scripting.Metadata/Microsoft.Scripting.Metadata.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <BaseAddress>859832320</BaseAddress>
     <CodeAnalysisRuleSet>$(AssemblyName).ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/Src/Microsoft.Scripting/Microsoft.Scripting.csproj
+++ b/Src/Microsoft.Scripting/Microsoft.Scripting.csproj
@@ -1,39 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
+    <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
 
-  <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
-    <BaseAddress>857735168</BaseAddress>
-    <CodeAnalysisRuleSet>$(AssemblyName).ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+        <BaseAddress>857735168</BaseAddress>
+        <CodeAnalysisRuleSet>$(AssemblyName).ruleset</CodeAnalysisRuleSet>
+        <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="..\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Configuration" Condition=" $(Features.Contains('FEATURE_CONFIGURATION')) " />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+        <Reference Include="System.Configuration" Condition=" $(Features.Contains('FEATURE_CONFIGURATION')) " />
+    </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
-    <PackageReference Include="System.CodeDom" Version="4.4.0" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
+        <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+        <PackageReference Include="System.CodeDom" Version="4.4.0" />
+    </ItemGroup>
 
-  <Import Project="$(BeforeTargetFiles)" />
+    <Import Project="$(BeforeTargetFiles)" />
 
-  <Target Name="BeforeBuildStarts" BeforeTargets="BeforeBuild" DependsOnTargets="$(BeforeTargets);GenerateCurrentVersion" />
+    <Target Name="BeforeBuildStarts" BeforeTargets="BeforeBuild" DependsOnTargets="$(BeforeTargets);GenerateCurrentVersion" />
 
-  <ItemGroup>
-    <!-- if the file does not exist it's not picked up automatically -->
-    <Compile Remove="Properties\CurrentVersion.Generated.cs" />
-    <Compile Include="Properties\CurrentVersion.Generated.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <!-- if the file does not exist it's not picked up automatically -->
+        <Compile Remove="Properties\CurrentVersion.Generated.cs" />
+        <Compile Include="Properties\CurrentVersion.Generated.cs" />
+    </ItemGroup>
 
-  <Import Project="$(AfterTargetFiles)" />
+    <Import Project="$(AfterTargetFiles)" />
 
-  <Target Name="AfterBuildEnds" AfterTargets="AfterBuild" DependsOnTargets="$(AfterTargets)" />
+    <Target Name="AfterBuildEnds" AfterTargets="AfterBuild" DependsOnTargets="$(AfterTargets)" />
 
 </Project>

--- a/Src/Microsoft.Scripting/PlatformAdaptationLayer.cs
+++ b/Src/Microsoft.Scripting/PlatformAdaptationLayer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Scripting {
 
         #region Assembly Loading
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_0
         static PlatformAdaptationLayer() {
             // https://github.com/dotnet/coreclr/issues/11498
             // attempt to resolve dependencies in the requesting directory

--- a/Src/Microsoft.Scripting/Utils/DelegateUtils.cs
+++ b/Src/Microsoft.Scripting/Utils/DelegateUtils.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Scripting.Utils {
                 MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public,
                 CallingConventions.Standard, _DelegateCtorSignature).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
             tb.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, typeof(object), paramTypes).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-            return tb.CreateType();
+            return tb.CreateTypeInfo().AsType();
         }
     }
 }

--- a/Src/Microsoft.Scripting/Utils/NativeMethods.cs
+++ b/Src/Microsoft.Scripting/Utils/NativeMethods.cs
@@ -12,7 +12,7 @@
  *
  *
  * ***************************************************************************/
-#if FEATURE_NATIVE || NETCOREAPP2_0
+#if FEATURE_NATIVE || NETCOREAPP2_0 || NETSTANDARD2_0
 
 using System;
 using System.Runtime.InteropServices;

--- a/Tests/Microsoft.Dynamic.Test/TestReflectionServices.cs
+++ b/Tests/Microsoft.Dynamic.Test/TestReflectionServices.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Dynamic.Test {
                 "DefaultIfEmpty", "ElementAt", "ElementAtOrDefault"
             }).ToList();
 
-#if !NETCOREAPP2_0 || !NETSTANDARD2_0
+#if !(NETCOREAPP2_0 || NETSTANDARD2_0)
             names.AddRange(
                 new string[] {
                     "AsQueryable", "AsQueryable", "AsParallel", "AsParallel", "AsParallel", "AsOrdered",

--- a/Tests/Microsoft.Dynamic.Test/TestReflectionServices.cs
+++ b/Tests/Microsoft.Dynamic.Test/TestReflectionServices.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Dynamic.Test {
                 "DefaultIfEmpty", "ElementAt", "ElementAtOrDefault"
             }).ToList();
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_0 || !NETSTANDARD2_0
             names.AddRange(
                 new string[] {
                     "AsQueryable", "AsQueryable", "AsParallel", "AsParallel", "AsParallel", "AsOrdered",


### PR DESCRIPTION
It's not a good idea for a lib only support netcoreapp2.0 profile.
I changed it to netstandard2.0  to let the libs use as less dependencies as possible.