### PR TITLE
Change EmitLoad(bool) to use boxed true/false values

### DIFF
--- a/Src/Microsoft.Dynamic/Ast/LightExceptionRewriter.cs
+++ b/Src/Microsoft.Dynamic/Ast/LightExceptionRewriter.cs
@@ -507,7 +507,7 @@ namespace Microsoft.Scripting.Ast {
             }
 
             public override int Run(InterpretedFrame frame) {
-                frame.Push(ScriptingRuntimeHelpers.BooleanToObject(LightExceptions.IsLightException(frame.Pop())));
+                frame.Push(LightExceptions.IsLightException(frame.Pop()));
                 return +1;
             }
         }

--- a/Src/Microsoft.Dynamic/Interpreter/Instructions/Instruction.cs
+++ b/Src/Microsoft.Dynamic/Interpreter/Instructions/Instruction.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Scripting.Interpreter {
         public override int ProducedStack => 1;
 
         public override int Run(InterpretedFrame frame) {
-            frame.Push((bool)frame.Pop() ? ScriptingRuntimeHelpers.False : ScriptingRuntimeHelpers.True);
+            frame.Push(!(bool)frame.Pop());
             return +1;
         }
     }

--- a/Src/Microsoft.Dynamic/Interpreter/Instructions/InstructionList.cs
+++ b/Src/Microsoft.Dynamic/Interpreter/Instructions/InstructionList.cs
@@ -290,9 +290,9 @@ namespace Microsoft.Scripting.Interpreter {
 
         public void EmitLoad(bool value) {
             if (value) {
-                Emit(_true ?? (_true = new LoadObjectInstruction(value)));
+                Emit(_true ?? (_true = new LoadObjectInstruction(ScriptingRuntimeHelpers.True)));
             } else {
-                Emit(_false ?? (_false = new LoadObjectInstruction(value)));
+                Emit(_false ?? (_false = new LoadObjectInstruction(ScriptingRuntimeHelpers.False)));
             }
         }
 

--- a/Src/Microsoft.Dynamic/Interpreter/Instructions/TypeOperations.cs
+++ b/Src/Microsoft.Dynamic/Interpreter/Instructions/TypeOperations.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Scripting.Interpreter {
 
         public override int Run(InterpretedFrame frame) {
             // unfortunately Type.IsInstanceOfType() is 35-times slower than "is T" so we use generic code:
-            frame.Push(ScriptingRuntimeHelpers.BooleanToObject(frame.Pop() is T));
+            frame.Push(frame.Pop() is T);
             return +1;
         }
 
@@ -136,7 +136,7 @@ namespace Microsoft.Scripting.Interpreter {
         public override int Run(InterpretedFrame frame) {
             object type = frame.Pop();
             object obj = frame.Pop();
-            frame.Push(ScriptingRuntimeHelpers.BooleanToObject(obj != null && (object)obj.GetType() == type));
+            frame.Push((object)obj?.GetType() == type);
             return +1;
         }
 


### PR DESCRIPTION
The changes in `InstructionList` resolve a minor issue with IronPython3 where `assert id(True) == id(True is True)` would fail. The other changes are just cleanup.