### PR TITLE
Support .Net Standard

### DIFF
--- a/Build/netstandard2.0.props
+++ b/Build/netstandard2.0.props
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <IsFullFramework>false</IsFullFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <Features>$(Features);FEATURE_APARTMENTSTATE</Features>
+        <Features>$(Features);FEATURE_APPLICATIONEXCEPTION</Features>
+        <Features>$(Features);FEATURE_ASSEMBLY_CODEBASE</Features>
+        <Features>$(Features);FEATURE_ASSEMBLY_LOCATION</Features>
+        <Features>$(Features);FEATURE_ASSEMBLY_RESOLVE</Features>
+        <Features>$(Features);FEATURE_ASSEMBLYBUILDER_DEFINEDYNAMICASSEMBLY</Features>
+        <Features>$(Features);FEATURE_BASIC_CONSOLE</Features>
+        <Features>$(Features);FEATURE_CODEDOM</Features>
+        <Features>$(Features);FEATURE_CONFIGURATION</Features>
+        <Features>$(Features);FEATURE_CUSTOM_TYPE_DESCRIPTOR</Features>
+        <Features>$(Features);FEATURE_DBNULL</Features>
+        <Features>$(Features);FEATURE_DRIVENOTFOUNDEXCEPTION</Features>
+        <Features>$(Features);FEATURE_DYNAMIC_EXPRESSION_VISITOR</Features>
+        <Features>$(Features);FEATURE_ENCODING</Features>
+        <Features>$(Features);FEATURE_EXCEPTION_STATE</Features>
+        <Features>$(Features);FEATURE_FILESYSTEM</Features>
+        <Features>$(Features);FEATURE_FULL_CONSOLE</Features>
+        <Features>$(Features);FEATURE_FULL_CRYPTO</Features>
+        <Features>$(Features);FEATURE_FULL_NET</Features>
+        <Features>$(Features);FEATURE_ICLONEABLE</Features>
+        <Features>$(Features);FEATURE_LCG</Features>
+        <Features>$(Features);FEATURE_LOADWITHPARTIALNAME</Features>
+        <Features>$(Features);FEATURE_METADATA_READER</Features>
+        <Features>$(Features);FEATURE_MMAP</Features>
+        <Features>$(Features);FEATURE_OS_SERVICEPACK</Features>
+        <Features>$(Features);FEATURE_PIPES</Features>
+        <Features>$(Features);FEATURE_PROCESS</Features>
+        <Features>$(Features);FEATURE_REFEMIT</Features>
+        <Features>$(Features);FEATURE_REGISTRY</Features>
+        <Features>$(Features);FEATURE_SECURITY_RULES</Features>
+        <Features>$(Features);FEATURE_SERIALIZATION</Features>
+        <Features>$(Features);FEATURE_SORTKEY</Features>
+        <Features>$(Features);FEATURE_STACK_TRACE</Features>
+        <Features>$(Features);FEATURE_SYNC_SOCKETS</Features>
+        <Features>$(Features);FEATURE_THREAD</Features>
+        <Features>$(Features);FEATURE_TYPE_EQUIVALENCE</Features>
+        <Features>$(Features);FEATURE_TYPECONVERTER</Features>
+        <Features>$(Features);FEATURE_WARNING_EXCEPTION</Features>
+        <Features>$(Features);FEATURE_WIN32EXCEPTION</Features>
+        <Features>$(Features);FEATURE_XMLDOC</Features>
+    </PropertyGroup>
+</Project>

--- a/Dlr.sln
+++ b/Dlr.sln
@@ -37,6 +37,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{60056F49
 		Build\net45.props = Build\net45.props
 		Build\netcoreapp2.0.props = Build\netcoreapp2.0.props
 		Build\netcoreapp2.1.props = Build\netcoreapp2.1.props
+		Build\netstandard2.0.props = Build\netstandard2.0.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Package", "Package", "{006DB050-2A71-4F36-BBE1-4AF6AF310C13}"

--- a/Package/nuget/DynamicLanguageRuntime.nuspec
+++ b/Package/nuget/DynamicLanguageRuntime.nuspec
@@ -27,8 +27,8 @@
       <group targetFramework="netstandard">
         <dependency id="System.CodeDom" version="4.5.0" />
         <dependency id="System.Configuration.ConfigurationManager" version="4.5.0" />
-        <dependency id="System.Reflection.Emit" Version="4.6.0-preview.19073.11" />
-        <dependency id="System.Reflection.Emit.Lightweight" Version="4.6.0-preview.19073.11" />
+        <dependency id="System.Reflection.Emit" version="4.6.0-preview.19073.11" />
+        <dependency id="System.Reflection.Emit.Lightweight" version="4.6.0-preview.19073.11" />
       </group>
     </dependencies>
   </metadata>

--- a/Package/nuget/DynamicLanguageRuntime.nuspec
+++ b/Package/nuget/DynamicLanguageRuntime.nuspec
@@ -24,7 +24,7 @@
         <dependency id="System.CodeDom" version="4.5.0" />
         <dependency id="System.Configuration.ConfigurationManager" version="4.5.0" />
       </group>
-      <group targetFramework="netstandard">
+      <group targetFramework="netstandard2.0">
         <dependency id="System.CodeDom" version="4.5.0" />
         <dependency id="System.Configuration.ConfigurationManager" version="4.5.0" />
         <dependency id="System.Reflection.Emit" version="4.6.0-preview.19073.11" />

--- a/Package/nuget/DynamicLanguageRuntime.nuspec
+++ b/Package/nuget/DynamicLanguageRuntime.nuspec
@@ -24,6 +24,12 @@
         <dependency id="System.CodeDom" version="4.5.0" />
         <dependency id="System.Configuration.ConfigurationManager" version="4.5.0" />
       </group>
+      <group targetFramework="netstandard">
+        <dependency id="System.CodeDom" version="4.5.0" />
+        <dependency id="System.Configuration.ConfigurationManager" version="4.5.0" />
+        <dependency id="System.Reflection.Emit" Version="4.6.0-preview.19073.11" />
+        <dependency id="System.Reflection.Emit.Lightweight" Version="4.6.0-preview.19073.11" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/Src/Microsoft.Dynamic/Debugging/DelegateHelpers.cs
+++ b/Src/Microsoft.Dynamic/Debugging/DelegateHelpers.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Scripting.Debugging {
             TypeBuilder builder = DefineDelegateType("Delegate_" + Guid.NewGuid().ToString());
             builder.DefineConstructor(CtorAttributes, CallingConventions.Standard, _DelegateCtorSignature).SetImplementationFlags(ImplAttributes);
             builder.DefineMethod("Invoke", InvokeAttributes, returnType, parameters).SetImplementationFlags(ImplAttributes);
-            return builder.CreateType();
+            return builder.CreateTypeInfo();
         }
 
         private static TypeBuilder DefineDelegateType(string name) {

--- a/Src/Microsoft.Dynamic/Generation/AssemblyGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/AssemblyGen.cs
@@ -346,7 +346,7 @@ namespace Microsoft.Scripting.Generation {
             TypeBuilder builder = DefineType(name, typeof(MulticastDelegate), DelegateAttributes, false);
             builder.DefineConstructor(CtorAttributes, CallingConventions.Standard, _DelegateCtorSignature).SetImplementationFlags(ImplAttributes);
             builder.DefineMethod("Invoke", InvokeAttributes, returnType, parameters).SetImplementationFlags(ImplAttributes);
-            return builder.CreateType();
+            return builder.CreateTypeInfo();
         }
     }
 }

--- a/Src/Microsoft.Dynamic/Generation/CompilerHelpers.cs
+++ b/Src/Microsoft.Dynamic/Generation/CompilerHelpers.cs
@@ -620,7 +620,7 @@ namespace Microsoft.Scripting.Generation {
             return (T)(object)LightCompile((LambdaExpression)lambda, compilationThreshold);
         }
 
-#if FEATURE_REFEMIT && !NETCOREAPP2_0 && !NETCOREAPP2_1
+#if FEATURE_REFEMIT && !NETCOREAPP2_0 && !NETCOREAPP2_1 && !NETSTANDARD2_0
         /// <summary>
         /// Compiles the lambda into a method definition.
         /// </summary>

--- a/Src/Microsoft.Dynamic/Generation/DynamicILGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/DynamicILGen.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Scripting.Generation {
         }
 
         private MethodInfo CreateMethod() {
-            Type t = _tb.CreateType();
+            Type t = _tb.CreateTypeInfo();
             return t.GetMethod(_mb.Name);
         }
 

--- a/Src/Microsoft.Dynamic/Generation/FieldBuilderExpression.cs
+++ b/Src/Microsoft.Dynamic/Generation/FieldBuilderExpression.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Scripting.Generation {
     public class FieldBuilderExpression : Expression {
         private readonly FieldBuilder _builder;
 
-#if NETCOREAPP2_0 || NETCOREAPP2_1
+#if NETCOREAPP2_0 || NETCOREAPP2_1 || NETSTANDARD2_0
         private readonly StrongBox<Type> _finishedType;
 
         // Get something which can be updated w/ the final type.
@@ -60,7 +60,7 @@ namespace Microsoft.Scripting.Generation {
 
         private FieldInfo GetFieldInfo() {
             // turn the field builder back into a FieldInfo
-#if NETCOREAPP2_0 || NETCOREAPP2_1
+#if NETCOREAPP2_0 || NETCOREAPP2_1 || NETSTANDARD2_0
             return _finishedType.Value.GetDeclaredField(_builder.Name);
 #else
             return _builder.DeclaringType.Module.ResolveField(

--- a/Src/Microsoft.Dynamic/Generation/ILGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/ILGen.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Scripting.Generation {
             _ilg.EmitCall(opcode, methodInfo, optionalParameterTypes);
         }
 
-#if (!NETCOREAPP2_0 && !NETSTANDARD2_0) || NETCOREAPP2_1
+#if !NETCOREAPP2_0 && !NETSTANDARD2_0
         /// <summary>
         /// Emits an unmanaged indirect call instruction.
         /// </summary>

--- a/Src/Microsoft.Dynamic/Generation/ILGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/ILGen.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Scripting.Generation {
             _ilg.EmitCall(opcode, methodInfo, optionalParameterTypes);
         }
 
-#if !NETCOREAPP2_0 || NETCOREAPP2_1
+#if (!NETCOREAPP2_0 && !NETSTANDARD2_0) || NETCOREAPP2_1
         /// <summary>
         /// Emits an unmanaged indirect call instruction.
         /// </summary>

--- a/Src/Microsoft.Dynamic/Generation/Snippets.cs
+++ b/Src/Microsoft.Dynamic/Generation/Snippets.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Scripting.Generation {
                 MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, 
                 CallingConventions.Standard, _DelegateCtorSignature).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
             tb.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, returnType, argTypes).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-            return tb.CreateType();
+            return tb.CreateTypeInfo();
 
         }
 

--- a/Src/Microsoft.Dynamic/Generation/ToDiskRewriter.cs
+++ b/Src/Microsoft.Dynamic/Generation/ToDiskRewriter.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Scripting.Generation {
             // SaveAssemblies mode prevents us from detecting the module as
             // transient. If that option is turned on, always replace delegates
             // that live in another AssemblyBuilder
-#if NETCOREAPP2_0 || NETCOREAPP2_1
+#if NETCOREAPP2_0 || NETCOREAPP2_1 || NETSTANDARD2_0
             return true; // TODO:
 #else
             var module = delegateType.Module as ModuleBuilder;

--- a/Src/Microsoft.Dynamic/Generation/TypeGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/TypeGen.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Scripting.Generation {
 
         public Type FinishType() {
             _initGen?.Emit(OpCodes.Ret);
-            Type ret = TypeBuilder.CreateType();
+            Type ret = TypeBuilder.CreateTypeInfo();
             return ret;
         }
 

--- a/Src/Microsoft.Dynamic/Microsoft.Dynamic.csproj
+++ b/Src/Microsoft.Dynamic/Microsoft.Dynamic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp2.1;netstandard2.0;</TargetFrameworks>
     <RootNamespace>Microsoft.Scripting</RootNamespace>
     <BaseAddress>859832320</BaseAddress>
     <CodeAnalysisRuleSet>..\..\DLR.ruleset</CodeAnalysisRuleSet>
@@ -14,14 +14,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Configuration" Condition=" $(Features.Contains('FEATURE_CONFIGURATION')) " />
+    <Reference Include="System.Configuration" Condition=" '$(TargetFramework)' == 'net45' AND $(Features.Contains('FEATURE_CONFIGURATION')) " />
     <Reference Include="System.Runtime.Remoting" Condition=" $(Features.Contains('FEATURE_REMOTING')) " />
     <Reference Include="System.Xaml" Condition=" $(Features.Contains('FEATURE_WPF')) " />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants.Replace(';FEATURE_FILESYSTEM', ''))</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Reflection.Emit" Version="4.6.0-preview.19073.11" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.6.0-preview.19073.11" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">

--- a/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
+++ b/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
@@ -687,7 +687,7 @@ namespace Microsoft.Scripting.Utils {
                 result.Append(' ');
             }
 
-#if FEATURE_REFEMIT && !NETCOREAPP2_0 && !NETCOREAPP2_1
+#if FEATURE_REFEMIT && !NETCOREAPP2_0 && !NETCOREAPP2_1 && !NETSTANDARD2_0
             MethodBuilder builder = method as MethodBuilder;
             if (builder != null) {
                 result.Append(builder.Signature);

--- a/Src/Microsoft.Scripting.Metadata/Microsoft.Scripting.Metadata.csproj
+++ b/Src/Microsoft.Scripting.Metadata/Microsoft.Scripting.Metadata.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp2.1;netstandard2.0;</TargetFrameworks>
     <BaseAddress>859832320</BaseAddress>
     <CodeAnalysisRuleSet>..\..\DLR.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/Src/Microsoft.Scripting/Microsoft.Scripting.csproj
+++ b/Src/Microsoft.Scripting/Microsoft.Scripting.csproj
@@ -1,19 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <BaseAddress>857735168</BaseAddress>
     <CodeAnalysisRuleSet>..\..\DLR.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="System.Configuration" Condition=" $(Features.Contains('FEATURE_CONFIGURATION')) " />
+    <Reference Include="System.Configuration" Condition=" '$(TargetFramework)' == 'net45' AND $(Features.Contains('FEATURE_CONFIGURATION')) " />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
+  </ItemGroup>
+
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Reflection.Emit" Version="4.6.0-preview.19073.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Microsoft.Scripting/Utils/DelegateUtils.cs
+++ b/Src/Microsoft.Scripting/Utils/DelegateUtils.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Scripting.Utils {
                 MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public,
                 CallingConventions.Standard, _DelegateCtorSignature).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
             tb.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, typeof(object), paramTypes).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-            return tb.CreateType();
+            return tb.CreateTypeInfo();
         }
     }
 }

--- a/Src/Microsoft.Scripting/Utils/NativeMethods.cs
+++ b/Src/Microsoft.Scripting/Utils/NativeMethods.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_NATIVE || NETCOREAPP2_0 || NETCOREAPP2_1
+#if FEATURE_NATIVE || NETCOREAPP2_0 || NETCOREAPP2_1 || NETSTANDARD2_0
 
 using System;
 using System.Runtime.InteropServices;

--- a/Tests/Microsoft.Dynamic.Test/TestReflectionServices.cs
+++ b/Tests/Microsoft.Dynamic.Test/TestReflectionServices.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Dynamic.Test {
                 "DefaultIfEmpty", "ElementAt", "ElementAtOrDefault"
             }).ToList();
 
-#if !NETCOREAPP2_0 && !NETCOREAPP2_1
+#if !NETCOREAPP2_0 && !NETCOREAPP2_1 && !NETSTANDARD2_0
             names.AddRange(
                 new string[] {
                     "AsQueryable", "AsQueryable", "AsParallel", "AsParallel", "AsParallel", "AsOrdered",

--- a/make.ps1
+++ b/make.ps1
@@ -4,7 +4,7 @@ Param(
     [Parameter(Position=1)]
     [String] $target = "release",
     [String] $configuration = "Release",
-    [String[]] $frameworks=@('net45','netcoreapp2.0','netcoreapp2.1'),
+    [String[]] $frameworks=@('net45','netcoreapp2.0','netcoreapp2.1', 'netstandard2.0'),
     [String] $platform = "x64",
     [switch] $runIgnored
 )

--- a/make.ps1
+++ b/make.ps1
@@ -4,7 +4,7 @@ Param(
     [Parameter(Position=1)]
     [String] $target = "release",
     [String] $configuration = "Release",
-    [String[]] $frameworks=@('net45','netcoreapp2.0','netcoreapp2.1', 'netstandard2.0'),
+    [String[]] $frameworks=@('net45','netcoreapp2.0','netcoreapp2.1'),
     [String] $platform = "x64",
     [switch] $runIgnored
 )


### PR DESCRIPTION
I have tested deploying this as a Nuget Package, referencing and using the nuget package from a .Net Standard class library, and then calling the library from both .Net Core and .Net Framework. Everything works as expected.

I hope that once this is merged, supporting .Net Standard for IronPython should be trivial.