### PR TITLE
Make make.ps1 executable in a portable way

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/pwsh
+#!/usr/bin/env pwsh
 [CmdletBinding()]
 Param(
     [Parameter(Position=1)]


### PR DESCRIPTION
Mirrors IronLanguages/ironpython3#564.