### PR TITLE
Fix double parsing for .NET Core 3

### DIFF
--- a/Src/Microsoft.Dynamic/Utils/MathUtils.cs
+++ b/Src/Microsoft.Dynamic/Utils/MathUtils.cs
@@ -734,20 +734,19 @@ namespace Microsoft.Scripting.Utils {
         }
 
         public static bool TryToFloat64(this BigInteger self, out double result) {
-            return StringUtils.TryParseDouble(
-                self.ToString(),
-                System.Globalization.NumberStyles.Number,
-                System.Globalization.CultureInfo.InvariantCulture.NumberFormat,
-                out result
-            );
+            result = (double)self;
+            if (double.IsInfinity(result)) {
+                result = default;
+                return false;
+            }
+            return true;
         }
 
         public static double ToFloat64(this BigInteger self) {
-            return double.Parse(
-                self.ToString(),
-                System.Globalization.NumberStyles.Number,
-                System.Globalization.CultureInfo.InvariantCulture.NumberFormat
-            );
+            if (TryToFloat64(self, out double res)) {
+                return res;
+            }
+            throw new OverflowException("Value was either too large or too small for a Double.");
         }
         
         public static int BitLength(BigInteger x) {

--- a/Src/Microsoft.Dynamic/Utils/StringUtils.cs
+++ b/Src/Microsoft.Dynamic/Utils/StringUtils.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Scripting.Utils {
             return result.ToString();
         }
 
+        [Obsolete("Use double.TryParse")]
         public static bool TryParseDouble(string s, NumberStyles style, IFormatProvider provider, out double result) {
             return Double.TryParse(s, style, provider, out result);
         }


### PR DESCRIPTION
With .NET Core 3, `Double.TryParse` no longer throws for values that are too large. Replace method to check for infinity and throw.