### PR TITLE
Expose MutableTuple.GetAccessPath with size

### DIFF
--- a/Src/Microsoft.Dynamic/MutableTuple.cs
+++ b/Src/Microsoft.Dynamic/MutableTuple.cs
@@ -177,13 +177,13 @@ namespace Microsoft.Scripting {
         /// Gets the series of properties that needs to be accessed to access a logical item in a potentially nested tuple.
         /// </summary>
         public static IEnumerable<PropertyInfo> GetAccessPath(Type tupleType, int index) {
-            return GetAccessProperties(tupleType, GetSize(tupleType), index);
+            return GetAccessPath(tupleType, GetSize(tupleType), index);
         }
 
         /// <summary>
         /// Gets the series of properties that needs to be accessed to access a logical item in a potentially nested tuple.
         /// </summary>
-        internal static IEnumerable<PropertyInfo> GetAccessProperties(Type tupleType, int size, int index) {
+        public static IEnumerable<PropertyInfo> GetAccessPath(Type tupleType, int size, int index) {
             ContractUtils.RequiresNotNull(tupleType, nameof(tupleType));
 
             if (index < 0 || index >= size) throw new ArgumentException(nameof(index));

--- a/Tests/Metadata/Metadata.csproj
+++ b/Tests/Metadata/Metadata.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="NUnitLite" Version="3.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/Microsoft.Dynamic.Test/Microsoft.Dynamic.Test.csproj
+++ b/Tests/Microsoft.Dynamic.Test/Microsoft.Dynamic.Test.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="NUnitLite" Version="3.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/Microsoft.Dynamic.Test/TestTuple.cs
+++ b/Tests/Microsoft.Dynamic.Test/TestTuple.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Scripting;
@@ -110,6 +111,28 @@ namespace Microsoft.Dynamic.Test {
             foreach (int i in new int[] { 1, 2, 4, 8, 16, 32, 64, 127, 128, 129, 256, 512, 1024, 24, 96 }) {
                 VerifyTuple(i);
             }
+        }
+
+        [Test]
+        public void TestNestedTupleSize() {
+            int size = 8;
+            Type[] args = new Type[size];
+            for (int i = 0; i < size; i++) {
+                if (i == 5) {
+                    var nestedTupleType = MutableTuple.MakeTupleType(typeof(int), typeof(int));
+                    args[i] = nestedTupleType;
+                } else {
+                    args[i] = typeof(int);
+                }
+            }
+
+            var tupleType = MutableTuple.MakeTupleType(args);
+
+            // these both fail - https://github.com/IronLanguages/dlr/issues/231
+            //Assert.AreEqual(MutableTuple.GetSize(tupleType), size);
+            //Assert.Throws<ArgumentException>(() => MutableTuple.GetAccessPath(tupleType, size).ToArray());
+            Assert.AreEqual(MutableTuple.GetSize(tupleType), size + 1);
+            Assert.Throws<InvalidOperationException>(() => MutableTuple.GetAccessPath(tupleType, size).ToArray());
         }
 
         [Test]

--- a/Tests/Microsoft.Scripting.Test/Microsoft.Scripting.Test.csproj
+++ b/Tests/Microsoft.Scripting.Test/Microsoft.Scripting.Test.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="NUnitLite" Version="3.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Specifying the size helps avoid running into the size issue explained in https://github.com/IronLanguages/dlr/issues/231