### PR TITLE
Support ParamDictionaryAttribute on IReadOnlyDictionary

### DIFF
--- a/Src/Microsoft.Dynamic/Actions/Calls/ParamsDictArgBuilder.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/ParamsDictArgBuilder.cs
@@ -89,12 +89,13 @@ namespace Microsoft.Scripting.Actions.Calls {
 
             if (dictType.IsGenericType) {
                 Type[] genArgs = dictType.GetGenericTypeArguments();
-                if (dictType.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>) && genArgs[0] == typeof(string)) {
+                if (dictType.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)) {
 
-                    MethodInfo target = typeof(BinderOps).GetMethod(nameof(BinderOps.MakeReadOnlyDictionary)).MakeGenericMethod(genArgs[1]);
+                    if (genArgs[0] == typeof(string) || genArgs[0] == typeof(object)) {
+                        MethodInfo target = typeof(BinderOps).GetMethod(nameof(BinderOps.MakeReadOnlyDictionary)).MakeGenericMethod(genArgs);
 
-                    func = (Func<string[], object[], object>)target.CreateDelegate(typeof(Func<string[], object[], object>));
-
+                        func = (Func<string[], object[], object>)target.CreateDelegate(typeof(Func<string[], object[], object>));
+                    }
                 } else if (dictType.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
                            dictType.GetGenericTypeDefinition() == typeof(Dictionary<,>)) {
 

--- a/Src/Microsoft.Dynamic/Actions/Calls/ParamsDictArgBuilder.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/ParamsDictArgBuilder.cs
@@ -87,19 +87,25 @@ namespace Microsoft.Scripting.Actions.Calls {
         private Func<string[], object[], object> GetCreationDelegate(Type dictType) {
             Func<string[], object[], object> func = null;
 
-            if (dictType == typeof(IDictionary)) {
-                func = BinderOps.MakeDictionary<object, object>;
-            } else if (dictType.IsGenericType) {
+            if (dictType.IsGenericType) {
                 Type[] genArgs = dictType.GetGenericTypeArguments();
-                if (dictType.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
-                    dictType.GetGenericTypeDefinition() == typeof(Dictionary<,>)) {
+                if (dictType.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>) && genArgs[0] == typeof(string)) {
+
+                    MethodInfo target = typeof(BinderOps).GetMethod(nameof(BinderOps.MakeReadOnlyDictionary)).MakeGenericMethod(genArgs[1]);
+
+                    func = (Func<string[], object[], object>)target.CreateDelegate(typeof(Func<string[], object[], object>));
+
+                } else if (dictType.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+                           dictType.GetGenericTypeDefinition() == typeof(Dictionary<,>)) {
 
                     if (genArgs[0] == typeof(string) || genArgs[0] == typeof(object)) {
-                        MethodInfo target = typeof(BinderOps).GetMethod("MakeDictionary").MakeGenericMethod(genArgs);
+                        MethodInfo target = typeof(BinderOps).GetMethod(nameof(BinderOps.MakeDictionary)).MakeGenericMethod(genArgs);
 
                         func = (Func<string[], object[], object>)target.CreateDelegate(typeof(Func<string[], object[], object>));
                     }
                 }
+            } else if (dictType == typeof(IDictionary)) {
+                func = BinderOps.MakeDictionary<object, object>;
             }
 
             if (func == null) {

--- a/Src/Microsoft.Dynamic/Runtime/BinderOps.cs
+++ b/Src/Microsoft.Dynamic/Runtime/BinderOps.cs
@@ -59,20 +59,13 @@ namespace Microsoft.Scripting.Runtime {
             return res;
         }
 
-        public static IReadOnlyDictionary<string, TValue> MakeReadOnlyDictionary<TValue>(string[] names, object[] values) {
-            var res = new Dictionary<string, TValue>(names.Length);
-
-            for (int i = 0; i < names.Length; i++) {
-                TValue v;
-                try {
-                    v = (TValue)values[i];
-                } catch (InvalidCastException) {
-                    throw new ArgumentTypeException($"Unable to cast keyword argument of type {CompilerHelpers.GetType(values[i])} to {typeof(TValue)}.");
-                }
-                res[names[i]] = v;
+        public static IReadOnlyDictionary<TKey, TValue> MakeReadOnlyDictionary<TKey, TValue>(string[] names, object[] values) {
+#if NETCOREAPP
+            if (names.Length == 0) {
+                return EmptyReadOnlyDictionary<TKey, TValue>.Instance;
             }
-
-            return res;
+#endif
+            return MakeDictionary<TKey, TValue>(names, values);
         }
 
         public static ArgumentTypeException BadArgumentsForOperation(ExpressionType op, params object[] args) {

--- a/Src/Microsoft.Dynamic/Runtime/BinderOps.cs
+++ b/Src/Microsoft.Dynamic/Runtime/BinderOps.cs
@@ -45,16 +45,36 @@ namespace Microsoft.Scripting.Runtime {
         public static Dictionary<TKey, TValue> MakeDictionary<TKey, TValue>(string[] names, object[] values) {
             Debug.Assert(typeof(TKey) == typeof(string) || typeof(TKey) == typeof(object));
 
-            Dictionary<TKey, TValue> res = new Dictionary<TKey, TValue>();
+            Dictionary<TKey, TValue> res = new Dictionary<TKey, TValue>(names.Length);
             IDictionary id = (IDictionary)res;
-            
+
             for (int i = 0; i < names.Length; i++) {
-                id[names[i]] = values[i];
+                try {
+                    id[names[i]] = values[i];
+                } catch (ArgumentException) {
+                    throw new ArgumentTypeException($"Unable to cast keyword argument of type {CompilerHelpers.GetType(values[i])} to {typeof(TValue)}.");
+                }
             }
 
             return res;
         }
-        
+
+        public static IReadOnlyDictionary<string, TValue> MakeReadOnlyDictionary<TValue>(string[] names, object[] values) {
+            var res = new Dictionary<string, TValue>(names.Length);
+
+            for (int i = 0; i < names.Length; i++) {
+                TValue v;
+                try {
+                    v = (TValue)values[i];
+                } catch (InvalidCastException) {
+                    throw new ArgumentTypeException($"Unable to cast keyword argument of type {CompilerHelpers.GetType(values[i])} to {typeof(TValue)}.");
+                }
+                res[names[i]] = v;
+            }
+
+            return res;
+        }
+
         public static ArgumentTypeException BadArgumentsForOperation(ExpressionType op, params object[] args) {
             StringBuilder message = new StringBuilder("unsupported operand type(s) for operation ");
             message.Append(op.ToString());

--- a/Src/Microsoft.Dynamic/Runtime/BinderOps.cs
+++ b/Src/Microsoft.Dynamic/Runtime/BinderOps.cs
@@ -60,11 +60,9 @@ namespace Microsoft.Scripting.Runtime {
         }
 
         public static IReadOnlyDictionary<TKey, TValue> MakeReadOnlyDictionary<TKey, TValue>(string[] names, object[] values) {
-#if NETCOREAPP
             if (names.Length == 0) {
                 return EmptyReadOnlyDictionary<TKey, TValue>.Instance;
             }
-#endif
             return MakeDictionary<TKey, TValue>(names, values);
         }
 

--- a/Src/Microsoft.Dynamic/Utils/CollectionExtensions.cs
+++ b/Src/Microsoft.Dynamic/Utils/CollectionExtensions.cs
@@ -141,11 +141,14 @@ namespace Microsoft.Scripting.Utils {
         internal static ReadOnlyCollection<T> Instance = new ReadOnlyCollection<T>(new T[0]);
     }
 
-#if NETCOREAPP
     internal static class EmptyReadOnlyDictionary<TKey, TValue> {
-        internal static IReadOnlyDictionary<TKey, TValue> Instance = System.Collections.Immutable.ImmutableDictionary.Create<TKey, TValue>();
-    }
+        internal static readonly IReadOnlyDictionary<TKey, TValue> Instance
+#if NETCOREAPP
+            = System.Collections.Immutable.ImmutableDictionary.Create<TKey, TValue>();
+#else
+            = new ReadOnlyDictionary<TKey, TValue>(new Dictionary<TKey, TValue>());
 #endif
+    }
 
     // TODO: Should we use this everywhere for empty arrays?
     // my thought is, probably more hassle than its worth

--- a/Src/Microsoft.Dynamic/Utils/CollectionExtensions.cs
+++ b/Src/Microsoft.Dynamic/Utils/CollectionExtensions.cs
@@ -140,6 +140,13 @@ namespace Microsoft.Scripting.Utils {
     internal static class EmptyReadOnlyCollection<T> {
         internal static ReadOnlyCollection<T> Instance = new ReadOnlyCollection<T>(new T[0]);
     }
+
+#if NETCOREAPP
+    internal static class EmptyReadOnlyDictionary<TKey, TValue> {
+        internal static IReadOnlyDictionary<TKey, TValue> Instance = System.Collections.Immutable.ImmutableDictionary.Create<TKey, TValue>();
+    }
+#endif
+
     // TODO: Should we use this everywhere for empty arrays?
     // my thought is, probably more hassle than its worth
     internal static class EmptyArray<T> {

--- a/Src/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
+++ b/Src/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Scripting {
     /// Most languages which support params dictionaries will support the following types:
     /// <code>
     ///     IReadOnlyDictionary&lt;string, anything&gt;<br/>
+    ///     IReadOnlyDictionary&lt;object, anything&gt;<br/>
     ///     IDictionary&lt;string, anything&gt;<br/>
     ///     IDictionary&lt;object, anything&gt;<br/>
     ///     Dictionary&lt;string, anything&gt;<br/>

--- a/Src/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
+++ b/Src/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
@@ -11,12 +11,14 @@ namespace Microsoft.Scripting {
     /// passed in a dictionary which is created for the call.
     /// 
     /// Most languages which support params dictionaries will support the following types:
-    ///     IDictionary&lt;string, anything&gt;
-    ///     IDictionary&lt;object, anything&gt;
-    ///     Dictionary&lt;string, anything&gt;
-    ///     Dictionary&lt;object, anything&gt;
+    /// <code>
+    ///     IReadOnlyDictionary&lt;string, anything&gt;<br/>
+    ///     IDictionary&lt;string, anything&gt;<br/>
+    ///     IDictionary&lt;object, anything&gt;<br/>
+    ///     Dictionary&lt;string, anything&gt;<br/>
+    ///     Dictionary&lt;object, anything&gt;<br/>
     ///     IDictionary
-    ///     IAttributesCollection (deprecated)
+    /// </code>
     /// 
     /// For languages which don't have language level support the user will be required to
     /// create and populate the dictionary by hand.
@@ -24,7 +26,7 @@ namespace Microsoft.Scripting {
     /// This attribute is the dictionary equivalent of the System.ParamArrayAttribute.
     /// </summary>
     /// <example>
-    /// public static void KeywordArgFunction([ParamsDictionary]IDictionary&lt;string, object&gt; dict) {
+    /// public static void KeywordArgFunction([ParamDictionary]IDictionary&lt;string, object&gt; dict) {
     ///     foreach (var v in dict) {
     ///         Console.WriteLine("Key: {0} Value: {1}", v.Key, v.Value);
     ///     }


### PR DESCRIPTION
This, when completed, will facilitate IronLanguages/ironpython3#882.

I implemented support only for `IReadOnlyDictionary<string, anything>` and not for `IReadOnlyDictionary<object, anything>` like for other generic types supported, because I fail to see any benefit of supporting dictionary interfaces that take `object` type as key, and sticking to `string` eliminates one cast for every runtime call for every kwarg param. The whole param dictionary machinery in DLR assumes that keyword parameter names are strings. If the client code really needs `<object, anything>` specialization to e.g. pass it on somehere down the road, it can always simply declare `Dictionary<object, something>`.