### PR TITLE
Coerce Extensible<string> to string if used as ParamDictionary key

### DIFF
--- a/Src/Microsoft.Dynamic/Actions/DefaultBinder.MethodCalls.cs
+++ b/Src/Microsoft.Dynamic/Actions/DefaultBinder.MethodCalls.cs
@@ -242,12 +242,14 @@ namespace Microsoft.Scripting.Actions {
             Type[] types = testTypes ? new Type[dict.Count] : null;
             int index = 0;
             while (dictEnum.MoveNext()) {
-                string name = dictEnum.Entry.Key as string;
-                if (name == null) {
+                if (dictEnum.Entry.Key is string name) {
+                    names[index] = name;
+                } else if (dictEnum.Entry.Key is Extensible<string> ename) {
+                    names[index] = ename.Value;
+                } else {
                     throw ScriptingRuntimeHelpers.SimpleTypeError(
-                        $"expected string for dictionary argument got {dictEnum.Entry.Key}");
+                        $"expected string for dictionary argument, got {dictEnum.Entry.Key}");
                 }
-                names[index] = name;
                 if (types != null) {
                     types[index] = CompilerHelpers.GetType(dictEnum.Entry.Value);
                 }
@@ -258,7 +260,7 @@ namespace Microsoft.Scripting.Actions {
                 Expression.AndAlso(
                     Expression.TypeIs(args[args.Count - 1].Expression, typeof(IDictionary)),
                     Expression.Call(
-                        typeof(BinderOps).GetMethod("CheckDictionaryMembers"),
+                        typeof(BinderOps).GetMethod(nameof(BinderOps.CheckDictionaryMembers)),
                         Expression.Convert(args[args.Count - 1].Expression, typeof(IDictionary)),
                         AstUtils.Constant(names),
                         testTypes ? AstUtils.Constant(types) : AstUtils.Constant(null, typeof(Type[]))


### PR DESCRIPTION
This facilitates IronLanguages/ironpython3#999.

It think ideally a given key should be coerced only when `[ParamDictionary]` is applied on a parameter of a generic type with `string` as `TKey`, while maintaining its identity for `object` cases. But this would require much ore extensive changes and so far I haven't see a need for it in IronPython. But the least the DLR can do is to **accept** `Extensible<string>` as the key type.

This coercing could also have been done at the IronPython level, but I believe it is more elegant in the DLR, and, frankly, where it belongs, sine `Extensible<>` is defined here too.