### PR TITLE
Explicit message for keyword/positional argument conflict

### DIFF
--- a/Src/Microsoft.Dynamic/Actions/Calls/ActualArguments.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/ActualArguments.cs
@@ -4,7 +4,9 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Dynamic;
+using System.Linq;
 
 using Microsoft.Scripting.Utils;
 
@@ -104,7 +106,7 @@ namespace Microsoft.Scripting.Actions.Calls {
                     if (paramIndex < positionalArgCount) {
                         // argument maps to already bound positional parameter
                         duppedNames ??= new List<string>();
-                        duppedPositionals ??= new List<int>(duppedNames.Count);
+                        duppedPositionals ??= Enumerable.Repeat(0, duppedNames.Count).ToList();
                         duppedNames.Add(ArgNames[i]);
                         duppedPositionals.Add(method.PositionOfParameter(ArgNames[i]));
                     } else if (boundParameters[nameIndex]) {
@@ -122,17 +124,17 @@ namespace Microsoft.Scripting.Actions.Calls {
                 }
             }
 
+            Debug.Assert(duppedPositionals == null || (duppedNames != null && duppedNames.Count == duppedPositionals.Count));
+
             binding = new ArgumentBinding(positionalArgCount, permutation);
 
             if (unboundNames != null) {
-                failure = new CallFailure(method, unboundNames.ToArray(), unassignable: true);
+                failure = new CallFailure(method, unboundNames.ToArray());
                 return false;
             }
 
             if (duppedNames != null) {
-                failure = duppedPositionals != null ?
-                    new CallFailure(method, duppedNames.ToArray(), duppedPositionals.ToArray()) :
-                    new CallFailure(method, duppedNames.ToArray(), unassignable: false);
+                failure = new CallFailure(method, duppedNames.ToArray(), duppedPositionals?.ToArray());
                 return false;
             }
 

--- a/Src/Microsoft.Dynamic/Actions/Calls/BindingTarget.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/BindingTarget.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Scripting.Actions.Calls {
 
         /// <summary>
         /// Creates a new BindingTarget when the method binding has failued due to 
-        /// one or more parameters which could not be converted.
+        /// one or more arguments which could not be converted or assigned to corresponding parameters.
         /// </summary>
         internal BindingTarget(string name, int actualArgumentCount, CallFailure[] failures) {
             Name = name;

--- a/Src/Microsoft.Dynamic/Actions/Calls/CallFailure.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/CallFailure.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
+
+using Microsoft.Scripting.Utils;
 
 namespace Microsoft.Scripting.Actions.Calls {
     /// <summary>
@@ -17,27 +20,41 @@ namespace Microsoft.Scripting.Actions.Calls {
     ///     the keywords which could not be assigned.
     /// If reason is DuplicateKeyword the KeywordArguments property will be non-null and include
     ///     the keywords which were duplicated (either by the keywords themselves or by positional
-    ///     arguments).
-    ///     
+    ///     arguments); also the PositionalArguments will be non-null and include the positions of positional
+    ///     arguments (if any, 0 otherwise) that were duplicated by the corresponding keyword arguments.
+    ///
     /// MethodTarget is always set and indicates the method which failed to bind.
     /// </summary>
     public sealed class CallFailure {
         private readonly ConversionResult[] _results;
         private readonly string[] _keywordArgs;
+        private readonly int[] _positionalArgs;
 
         internal CallFailure(MethodCandidate candidate, ConversionResult[] results) {
             Candidate = candidate;
-            _results = results;
             Reason = CallFailureReason.ConversionFailure;
+            _results = results;
         }
 
         internal CallFailure(MethodCandidate candidate, string[] keywordArgs, bool unassignable) {
-            Reason = unassignable ? CallFailureReason.UnassignableKeyword : CallFailureReason.DuplicateKeyword;
             Candidate = candidate;
+            Reason = unassignable ? CallFailureReason.UnassignableKeyword : CallFailureReason.DuplicateKeyword;
             _keywordArgs = keywordArgs;
+            _positionalArgs = EmptyArray<int>.Instance;
+        }
+
+        internal CallFailure(MethodCandidate candidate, string[] keywordArgs, int[] positionalArgs) {
+            Candidate = candidate;
+            Reason = CallFailureReason.DuplicateKeyword;
+            _keywordArgs = keywordArgs;
+            _positionalArgs = positionalArgs;
         }
 
         internal CallFailure(MethodCandidate candidate, CallFailureReason reason) {
+            Debug.Assert(reason != CallFailureReason.ConversionFailure); // use first overload
+            Debug.Assert(reason != CallFailureReason.UnassignableKeyword); // use second overload
+            Debug.Assert(reason != CallFailureReason.DuplicateKeyword); // use second or third overload
+
             Candidate = candidate;
             Reason = reason;
         }
@@ -57,13 +74,24 @@ namespace Microsoft.Scripting.Actions.Calls {
         /// Gets a list of ConversionResult's for each parameter indicating
         /// whether the conversion was successful or failed and the types
         /// being converted.
+        /// This property has a meaningful value only when Reason == ConversionFailure
         /// </summary>
         public IList<ConversionResult> ConversionResults => _results;
 
         /// <summary>
-        /// Gets the list of keyword arguments that were either dupliated or
+        /// Gets the list of keyword arguments that were either duplicated or
         /// unassignable.
+        /// This property has a meaningful value only when Reason == UnassignableKeyword or DuplicateKeyword
         /// </summary>
         public IList<string> KeywordArguments => _keywordArgs;
+
+        /// <summary>
+        /// Gets 1-based positions of positional arguments that were duplicated
+        /// by the corresponding (by index) keyword arguments from KeywordArguments.
+        /// Value 0 of the position means that no positional argument is duplicated by the corresponding keyword argument.
+        /// The list may be shorter than KeywordArguments, in such case all missing elements are assumed 0.
+        /// This property has a meaningful value only when Reason == DuplicateKeyword
+        /// </summary>
+        public IList<int> PositionalArguments => _positionalArgs;
     }
 }

--- a/Src/Microsoft.Dynamic/Actions/Calls/CallFailure.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/CallFailure.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Scripting.Actions.Calls {
             _results = results;
         }
 
-        internal CallFailure(MethodCandidate candidate, string[] keywordArgs, bool unassignable) {
+        internal CallFailure(MethodCandidate candidate, string[] keywordArgs) {
             Candidate = candidate;
-            Reason = unassignable ? CallFailureReason.UnassignableKeyword : CallFailureReason.DuplicateKeyword;
+            Reason = CallFailureReason.UnassignableKeyword;
             _keywordArgs = keywordArgs;
             _positionalArgs = EmptyArray<int>.Instance;
         }
@@ -47,13 +47,13 @@ namespace Microsoft.Scripting.Actions.Calls {
             Candidate = candidate;
             Reason = CallFailureReason.DuplicateKeyword;
             _keywordArgs = keywordArgs;
-            _positionalArgs = positionalArgs;
+            _positionalArgs = positionalArgs ?? EmptyArray<int>.Instance;
         }
 
         internal CallFailure(MethodCandidate candidate, CallFailureReason reason) {
             Debug.Assert(reason != CallFailureReason.ConversionFailure); // use first overload
             Debug.Assert(reason != CallFailureReason.UnassignableKeyword); // use second overload
-            Debug.Assert(reason != CallFailureReason.DuplicateKeyword); // use second or third overload
+            Debug.Assert(reason != CallFailureReason.DuplicateKeyword); // use third overload
 
             Candidate = candidate;
             Reason = reason;

--- a/Src/Microsoft.Dynamic/Actions/Calls/CandidateSet.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/CandidateSet.cs
@@ -39,7 +39,10 @@ namespace Microsoft.Scripting.Actions.Calls {
         }
 
         public override string ToString() {
-            return $"{_arity}: ({_candidates[0].Overload.Name} on {_candidates[0].Overload.DeclaringType.FullName})";
+            return
+                _candidates.Count > 1 ? $"{_arity}: ({_candidates[0].Overload.Name} on {_candidates[0].Overload.DeclaringType.FullName}, <{_candidates.Count-1} more>)" :
+                _candidates.Count > 0 ? $"{_arity}: ({_candidates[0].Overload.Name} on {_candidates[0].Overload.DeclaringType.FullName})" :
+                $"{_arity}: (<empty>)";
         }
     }
 }

--- a/Src/Microsoft.Dynamic/Actions/Calls/MethodCandidate.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/MethodCandidate.cs
@@ -97,12 +97,13 @@ namespace Microsoft.Scripting.Actions.Calls {
 
         internal int PositionOfParameter(string name) {
             for (int i = 0, p = 1; i < _parameters.Count; i++) {
-                if (_parameters[i].IsHidden) {
-                    if (_parameters[i].Name == name) {
+                var parameter = _parameters[i];
+                if (parameter.IsHidden) {
+                    if (parameter.Name == name) {
                         return 0;
                     }
                 } else {
-                    if (_parameters[i].Name == name) {
+                    if (parameter.Name == name) {
                         return p;
                     }
                     p++;

--- a/Src/Microsoft.Dynamic/Actions/Calls/MethodCandidate.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/MethodCandidate.cs
@@ -95,6 +95,22 @@ namespace Microsoft.Scripting.Actions.Calls {
             return -1;
         }
 
+        internal int PositionOfParameter(string name) {
+            for (int i = 0, p = 1; i < _parameters.Count; i++) {
+                if (_parameters[i].IsHidden) {
+                    if (_parameters[i].Name == name) {
+                        return 0;
+                    }
+                } else {
+                    if (_parameters[i].Name == name) {
+                        return p;
+                    }
+                    p++;
+                }
+            }
+            return -1;
+        }
+
         public int GetVisibleParameterCount() {
             int result = 0;
             foreach (var parameter in _parameters) {

--- a/Src/Microsoft.Dynamic/Actions/Calls/OverloadResolver.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/OverloadResolver.cs
@@ -1045,15 +1045,29 @@ namespace Microsoft.Scripting.Actions.Calls {
                         }
                         break;
                     case CallFailureReason.DuplicateKeyword:
-                        return ErrorInfo.FromException(
-                            Expression.Call(
-                                typeof(BinderOps).GetMethod("TypeErrorForDuplicateKeywordArgument"),
-                                AstUtils.Constant(target.Name, typeof(string)),
-                                AstUtils.Constant(
-                                    cf.KeywordArguments[0],
-                                    typeof(string)) // TODO: Report all bad arguments?
+                        int duppedIdx = cf.PositionalArguments.FindIndex(p => p != 0);
+                        return duppedIdx >= 0 ?
+                            ErrorInfo.FromException(
+                                Expression.Call(
+                                    typeof(BinderOps).GetMethod(nameof(BinderOps.TypeErrorForDuplicateArgument)),
+                                    AstUtils.Constant(target.Name, typeof(string)),
+                                    AstUtils.Constant(
+                                        cf.PositionalArguments[duppedIdx],
+                                        typeof(int)),
+                                    AstUtils.Constant(
+                                        cf.KeywordArguments[duppedIdx],
+                                        typeof(string)) // TODO: Report all bad arguments?
+                                )
                             )
-                        );
+                          : ErrorInfo.FromException(
+                                Expression.Call(
+                                    typeof(BinderOps).GetMethod(nameof(BinderOps.TypeErrorForDuplicateKeywordArgument)),
+                                    AstUtils.Constant(target.Name, typeof(string)),
+                                    AstUtils.Constant(
+                                        cf.KeywordArguments[0],
+                                        typeof(string)) // TODO: Report all bad arguments?
+                                )
+                            );
                     case CallFailureReason.UnassignableKeyword:
                         return ErrorInfo.FromException(
                             Expression.Call(

--- a/Src/Microsoft.Dynamic/Actions/Calls/ParamsDictArgBuilder.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/ParamsDictArgBuilder.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Scripting.Actions.Calls {
 
         protected internal override Expression ToExpression(OverloadResolver resolver, RestrictedArguments args, bool[] hasBeenUsed) {
             Type dictType = ParameterInfo.ParameterType;
+            // TODO: bug: what if ConstantNames().Length > hasBeenUsed.Count(b => !b)?
 
             return Expression.Call(
                 GetCreationDelegate(dictType).GetMethodInfo(),

--- a/Src/Microsoft.Dynamic/Runtime/BinderOps.cs
+++ b/Src/Microsoft.Dynamic/Runtime/BinderOps.cs
@@ -152,6 +152,10 @@ namespace Microsoft.Scripting.Runtime {
             return new ArgumentTypeException($"{name}() got multiple values for keyword argument '{argumentName}'");
         }
 
+        public static ArgumentTypeException TypeErrorForDuplicateArgument(string name, int position, string argumentName) {
+            return new ArgumentTypeException($"Argument for {name}() given by name ('{argumentName}') and position ({position})");
+        }
+
         public static ArgumentTypeException TypeErrorForNonInferrableMethod(string name) {
             return new ArgumentTypeException(
                 $"The type arguments for method '{name}' cannot be inferred from the usage. Try specifying the type arguments explicitly.");

--- a/Tests/ClrAssembly/Src/methodargs.cs
+++ b/Tests/ClrAssembly/Src/methodargs.cs
@@ -41,6 +41,7 @@ namespace Merlin.Testing.Call {
         public void M235([Optional] EnumInt32 arg) { Flag<EnumInt32>.Set(arg); }
         public void M236([Optional] SimpleClass arg) { Flag<SimpleClass>.Set(arg); }
         public void M237([Optional] SimpleStruct arg) { Flag<SimpleStruct>.Set(arg); }
+        public void M240([Optional] int x, int y) { Flag.Set(x * 10 + y); }
 
         // two parameters
         public void M300(int x, int y) { }
@@ -61,7 +62,9 @@ namespace Merlin.Testing.Call {
         public void M510(int x, int y, [DefaultParameterValue(70)] int z) { Flag.Set(x * 100 + y * 10 + z); }
         public void M520(int x, [DefaultParameterValue(80)]int y, int z) { Flag.Set(x * 100 + y * 10 + z); }
         public void M530([DefaultParameterValue(90)]int x, int y, int z) { Flag.Set(x * 100 + y * 10 + z); }
+        public void M540([DefaultParameterValue(100)] int x, [DefaultParameterValue(110)] int y, int z) { Flag.Set(x + y + z); }
         public void M550(int x, int y, params int[] z) { Flag.Set(x * 100 + y * 10 + z.Length); }
+        public void M560(int x, [ParamDictionary] IDictionary<string, int> y, params int[] z) { Flag.Set(x * 100 + y.Count * 10 + z.Length); }
 
         // long paramater list
         public void M650(int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10) {


### PR DESCRIPTION
There are a number of issues with the DLR overload resolver, which I am looking into now, but the code is so wonderfully complex that I prefer to start with something simple, to build confidence. Here is such change: it is not functional (it doesn't change how the resolving happens), it merely makes the error messages more specific in case of duplicate arguments.

Currently, for duplicate arguments, the message is "_MethodName_() got multiple values for keyword argument '_arg_'". To me it suggests that a keyword argument _arg_ is duplicated, but it can also be reported when an argument is provided by position and keyword, which is also a clash.

To be more accurate, positional/keyword clash is not handled well at all, sometimes resulting in strange messages as "_MethodName_() takes at least 2 arguments (6 given)", `IndexOutOfRangeException`, or simply no error but incorrect behaviour. Looking into the code, it seems to me that handling all those cases is not quite finished. But in this PR, I only want to establish what the appropiate error message should be in such cases, and than later build on it when resolving the actual problems.

For reference, Python (CPython) will issue  "_funcname_() got multiple values for keyword argument '_arg_'" **only** when there is a keyword/keyword clash. For positional/keyword clash, CPython uses "_funcname_() got multiple values for argument '_arg_'" (for user defined functions) and "argument for _funcname_() given by name ('_arg_') and position (_n_)" (for built-in functions). Not that DLR has to follow Python, but lacking better ideas I borrowed the builtin message from Python here.

Some notes about the implementation choices: the reason for a specific method binding failure is being carried around in an object of type `CallFailure`. This class has a property `Reason` of enum type `CallFailureReason`. I was tempted to add a new constant to that enum, say, `DuplicateArgument`, but it is in public API, so worth some consideration. On one hand, [.NET Core guidelines](https://docs.microsoft.com/en-us/dotnet/core/compatibility/) allow it, but what would clients do when they read a value that falls outside the expected enum range? Also, [reading comments on the `DuplicateKeyword` contant](https://github.com/IronLanguages/dlr/blob/57dea695e634b221f61b564746ce4aa3c76e66f7/Src/Microsoft.Dynamic/Actions/Calls/CallFailureReason.cs#L24), it seems that the original intent was to cover both cases with the same enum. So I settled on a change that adds an extra property enabling to differentiate the two cases further down the road. Besides, the extra property carries useful information for error reporting. (Although, looking ahead, I see opportunity/need to add more enum values for some new cases). The type of the property could be better `IReadOnlyList<int>`, but that is also true for the other like-like properties, so I stayed with `List<int>` for consistency. 

Arguably, the error message could have simply been "_MethodName_() got multiple values for argument '_arg_'", but since the information abouth the positional argument is there, why not show it to the user. It will either help the user to diagnose their problem (if the reported position correct), or help us to spot bugs in the DLR (if incorrect).

This brings me to the last point: about the meaning of the _position_. As I see it, it can be interpreted as either a position of the offending argument that is given without a name, or a position of the parameter, which is being claimed by a positional argument and a keyword argument. Typically they are the same, but not always. Personally, as a user, I would expect the position of the argument being reported, but the DLR reports the position of the parameter. Also, interestingly, CPython reports the position of the parameter, so I assume this is fine. Here is an example:

~~~
Python 3.4.4 (v3.4.4:737efcadf5a6, Dec 20 2015, 20:20:57) [MSC v.1600 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> datetime.date(year=2020, *(11, 2)) 
Traceback (most recent call last):   
  File "<stdin>", line 1, in <module>
TypeError: Argument given by name ('year') and position (1)
~~~

