### PR TITLE
Prevent ParamArray and ParamDictionary parameters from binding by keyword

### DIFF
--- a/Src/Microsoft.Dynamic/Actions/Calls/DefaultOverloadResolver.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/DefaultOverloadResolver.cs
@@ -139,9 +139,10 @@ namespace Microsoft.Scripting.Actions {
             }
         }
 
-        // TODO: review the signature, add protected
-        internal override bool AllowByKeywordArgument(OverloadInfo method, ParameterInfo parameter) {
-            return !parameter.ProhibitsByKeyword();
+        protected internal override bool AllowByKeywordArgument(OverloadInfo method, ParameterInfo parameter) {
+            // params arrays & dictionaries don't allow assignment by keyword
+            return base.AllowByKeywordArgument(method, parameter)
+                && !parameter.IsParamArray() && !parameter.IsParamDictionary();
         }
 
         protected override ActualArguments CreateActualArguments(IList<DynamicMetaObject> namedArgs, IList<string> argNames, int preSplatLimit, int postSplatLimit) {

--- a/Src/Microsoft.Dynamic/Actions/Calls/OverloadResolver.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/OverloadResolver.cs
@@ -158,21 +158,21 @@ namespace Microsoft.Scripting.Actions.Calls {
         /// Checks to see if the language allows named arguments to be bound to instance fields or
         /// properties and turned into setters. By default this is only allowed on contructors.
         /// </summary>
-        internal protected virtual bool AllowMemberInitialization(OverloadInfo method) {
+        protected internal virtual bool AllowMemberInitialization(OverloadInfo method) {
 #pragma warning disable 618 // obsolete
             return AllowKeywordArgumentSetting(method.ReflectionInfo);
 #pragma warning restore 618
         }
 
         [Obsolete("Use OverloadInfo.AllowMemberInitialization instead")]
-        internal protected virtual bool AllowKeywordArgumentSetting(MethodBase method) {
+        protected internal virtual bool AllowKeywordArgumentSetting(MethodBase method) {
             return CompilerHelpers.IsConstructor(method);
         }
 
         /// <summary>
         /// Gets an expression that evaluates to the result of GetByRefArray operation.
         /// </summary>
-        internal protected virtual Expression GetByRefArrayExpression(Expression argumentArrayExpression) {
+        protected internal virtual Expression GetByRefArrayExpression(Expression argumentArrayExpression) {
             return argumentArrayExpression;
         }
 
@@ -186,11 +186,20 @@ namespace Microsoft.Scripting.Actions.Calls {
         /// <summary>
         /// Checks whether the given parameter may be mapped to by a keyword argument.
         /// </summary>
+        /// <remarks>
+        /// If overriden, the derived class may only add more constraints to the constraints from the base class.
+        /// </remarks>
+        /// <example>
+        /// <code><![CDATA[
+        /// protected internal override bool AllowByKeywordArgument(OverloadInfo method, ParameterInfo parameter)
+        ///   => base.AllowByKeywordArgument(method, parameter)
+        ///      && AdditionalCheckIfByKeywordAllowed(method, parameter);
+        /// ]]></code>
+        /// </example>
         /// <seealso cref="GetNamedArguments"/>
         /// <seealso cref="BindToUnexpandedParams"/>
-        // TODO: review the signature, add protected
-        internal virtual bool AllowByKeywordArgument(OverloadInfo method, ParameterInfo parameter) {
-            return true; // legacy behavior, but by default OverloadResolver doesn't recognize named arguments anyway
+        protected internal virtual bool AllowByKeywordArgument(OverloadInfo method, ParameterInfo parameter) {
+            return  true; // no constraints, but by default OverloadResolver doesn't recognize named arguments anyway
         }
 
         /// <summary>
@@ -201,7 +210,7 @@ namespace Microsoft.Scripting.Actions.Calls {
         /// A default mapping will be constructed for the remaining parameters (cleared bits).
         /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "3#")]
-        internal protected virtual BitArray MapSpecialParameters(ParameterMapping mapping) {
+        protected internal virtual BitArray MapSpecialParameters(ParameterMapping mapping) {
             if (!mapping.Overload.IsStatic) {
                 var type = mapping.Overload.DeclaringType;
                 mapping.AddParameter(new ParameterWrapper(null, type, null, ParameterBindingFlags.ProhibitNull));

--- a/Src/Microsoft.Dynamic/Actions/Calls/OverloadResolver.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/OverloadResolver.cs
@@ -184,6 +184,16 @@ namespace Microsoft.Scripting.Actions.Calls {
         }
 
         /// <summary>
+        /// Checks whether the given parameter may be mapped to by a keyword argument.
+        /// </summary>
+        /// <seealso cref="GetNamedArguments"/>
+        /// <seealso cref="BindToUnexpandedParams"/>
+        // TODO: review the signature, add protected
+        internal virtual bool AllowByKeywordArgument(OverloadInfo method, ParameterInfo parameter) {
+            return true; // legacy behavior, but by default OverloadResolver doesn't recognize named arguments anyway
+        }
+
+        /// <summary>
         /// Called before arguments binding.
         /// </summary>
         /// <returns>
@@ -289,7 +299,7 @@ namespace Microsoft.Scripting.Actions.Calls {
 
             var mapping = new ParameterMapping(this, method, _argNames);
 
-            mapping.MapParameters(false);
+            mapping.MapParameters(reduceByRef: false);
 
             foreach (var defaultCandidate in mapping.CreateDefaultCandidates()) {
                 AddSimpleTarget(defaultCandidate);
@@ -1188,11 +1198,15 @@ namespace Microsoft.Scripting.Actions.Calls {
         }
 
         public override string ToString() {
-            string res = string.Empty;
-            foreach (CandidateSet set in _candidateSets.Values) {
-                res += set + Environment.NewLine;
+            if (_candidateSets != null) {
+                string res = string.Empty;
+                foreach (CandidateSet set in _candidateSets.Values) {
+                    res += set + Environment.NewLine;
+                }
+                return res;
+            } else {
+                return $"<unresolved {nameof(OverloadResolver)}>";
             }
-            return res;
         }
     }
 }

--- a/Src/Microsoft.Dynamic/Actions/Calls/ParameterMapping.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/ParameterMapping.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Scripting.Actions.Calls {
 
         public void MapParameter(ParameterInfo pi) {
             int indexForArgBuilder;
-            int nameIndex = _argNames.IndexOf(pi.Name);
+            int nameIndex = _resolver.AllowByKeywordArgument(Overload, pi) ? _argNames.IndexOf(pi.Name) : -1;
             if (nameIndex == -1) {
                 // positional argument, we simply consume the next argument
                 indexForArgBuilder = ArgIndex++;

--- a/Src/Microsoft.Dynamic/Actions/Calls/ParamsDictArgBuilder.cs
+++ b/Src/Microsoft.Dynamic/Actions/Calls/ParamsDictArgBuilder.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -38,12 +39,15 @@ namespace Microsoft.Scripting.Actions.Calls {
 
         protected internal override Expression ToExpression(OverloadResolver resolver, RestrictedArguments args, bool[] hasBeenUsed) {
             Type dictType = ParameterInfo.ParameterType;
-            // TODO: bug: what if ConstantNames().Length > hasBeenUsed.Count(b => !b)?
+            var names = ConstantNames();
+            var expressions = GetParameters(args, hasBeenUsed);
+
+            Debug.Assert(names.Length == expressions.Count);
 
             return Expression.Call(
                 GetCreationDelegate(dictType).GetMethodInfo(),
-                Expression.NewArrayInit(typeof(string), ConstantNames()),
-                AstUtils.NewArrayHelper(typeof(object), GetParameters(args, hasBeenUsed))
+                Expression.NewArrayInit(typeof(string), names),
+                AstUtils.NewArrayHelper(typeof(object), expressions)
             );
         }
 

--- a/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
+++ b/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
@@ -1004,13 +1004,6 @@ namespace Microsoft.Scripting.Utils {
             return parameter.IsDefined(typeof(ParamDictionaryAttribute), false);
         }
 
-        // TODO: revisit, make public or eliminate
-        internal static bool ProhibitsByKeyword(this ParameterInfo parameter) {
-            // params arrays & dictionaries don't allow assignment by keyword
-            return parameter.IsParamArray() || parameter.IsParamDictionary();
-            // TODO: extend if NonKeywordAttribute introduced
-        }
-
         public static bool IsParamsMethod(MethodBase method) {
             return IsParamsMethod(method.GetParameters());
         }

--- a/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
+++ b/Src/Microsoft.Dynamic/Utils/ReflectionUtils.cs
@@ -1004,6 +1004,13 @@ namespace Microsoft.Scripting.Utils {
             return parameter.IsDefined(typeof(ParamDictionaryAttribute), false);
         }
 
+        // TODO: revisit, make public or eliminate
+        internal static bool ProhibitsByKeyword(this ParameterInfo parameter) {
+            // params arrays & dictionaries don't allow assignment by keyword
+            return parameter.IsParamArray() || parameter.IsParamDictionary();
+            // TODO: extend if NonKeywordAttribute introduced
+        }
+
         public static bool IsParamsMethod(MethodBase method) {
             return IsParamsMethod(method.GetParameters());
         }

--- a/Src/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
+++ b/Src/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
@@ -6,8 +6,8 @@ using System;
 
 namespace Microsoft.Scripting {
     /// <summary>
-    /// This attribute is used to mark a parameter that can accept any keyword parameters that
-    /// are not bound to normal arguments.  The extra keyword parameters will be
+    /// This attribute is used to mark a parameter that can accept any keyword arguments that
+    /// are not bound to normal parameters.  The extra keyword arguments will be
     /// passed in a dictionary which is created for the call.
     /// 
     /// Most languages which support params dictionaries will support the following types:

--- a/Tests/ClrAssembly/Src/methodargs.cs
+++ b/Tests/ClrAssembly/Src/methodargs.cs
@@ -30,7 +30,9 @@ namespace Merlin.Testing.Call {
         public void M200(int arg) { Flag.Set(arg); }
         public void M201([DefaultParameterValue(20)] int arg) { Flag.Set(arg); }
         public void M202(params int[] arg) { Flag.Set(arg.Length); }
-        public void M203([ParamDictionaryAttribute] IDictionary<object, object> arg) { Flag.Set(arg.Count); }
+        public void M203([ParamDictionary] IDictionary<object, object> arg) { Flag.Set(arg.Count); }
+        public void M204(params object[] arg) { Flag.Set(arg.Length); }
+        public void M205([ParamDictionary] IDictionary<string, int> arg) { Flag.Set(arg.Count); }
 
         // optional (get missing value)
         // - check the value actually passed in
@@ -46,11 +48,11 @@ namespace Merlin.Testing.Call {
         // two parameters
         public void M300(int x, int y) { }
         public void M350(int x, params int[] y) { }
-        public void M351(int x, [ParamDictionary] IDictionary<object, object> arg) { Flag<object>.Set(arg); }
-        public void M352([ParamDictionary] IDictionary<object, object> arg, params int[] x) { Flag<object>.Set(arg); }
+        public void M351(int x, [ParamDictionary] IDictionary<object, object> y) { Flag<object>.Set(y); }
+        public void M352([ParamDictionary] IDictionary<object, object> x, params object[] y) { Flag<object>.Set(x); }
 
         public void M310(int x, [DefaultParameterValue(30)]int y) { Flag.Set(x + y); }
-        public void M320([DefaultParameterValue(40)] int y, int x) { Flag.Set(x + y); }
+        public void M320([DefaultParameterValue(40)] int x, int y) { Flag.Set(x + y); }
         public void M330([DefaultParameterValue(50)] int x, [DefaultParameterValue(60)] int y) { Flag.Set(x + y); }
 
         public void M410(int x, [Optional]int y) { }


### PR DESCRIPTION
This fixes

```Python
import clr
clr.AddReference("rowantest.methodargs")
from Merlin.Testing.Call import VariousParameters
obj = VariousParameters()
obj.M560(1, 2, 3, z=4, b=5, c=6)
```

reported in #249.

Disabling by-keyword assignment to param arrays and dictionaries is controlled though a virtual method on `OverloadResolver`, but I stopped short from making it protected since the DLR currently cannot handle the "enabled" case so I did not want the languages to start requesting it. It can go in three ways from here:

1. The DLR implements `PositonalOnlyAttribute`/`NonKeywordAttribute` for the benefit of all languages. Probably the best way to support it is in `ReflectionUtils` and the virtual extension point maybe can be abolished (i.e. preventing binding by keyword to param arrays/dictionaries will be hard-coded).
2. `PositonalOnlyAttribute`/`NonKeywordAttribute` will be implemented at the language level (i.e. in IronPython), and the virtual extension point will become protected and overridden in `PythonOverloadResolver`, (or any other language-specific resolver derived from `DefaultOverloadResolver`, with the provision that the language can only tighten the restriction rather than relax it).
3. The DLR will somehow be upgraded/cleaned/up/extended to be able to handle param arrays/dictionaries being bound by keyword, by some to be determined consistent set of rules. Then the virtual extension point can become protected without any restrictions.