### PR TITLE
BlazorWasm support

### DIFF
--- a/Src/Microsoft.Scripting/Runtime/SharedIO.cs
+++ b/Src/Microsoft.Scripting/Runtime/SharedIO.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Scripting.Runtime {
                         _inputStream = Stream.Null;
                         _inputReader = TextReader.Null;
 #endif
-                        } catch (TypeInitializationException) {
+                        } catch (PlatformNotSupportedException) {
                             // When on BlazorWebassembly, this exception is thrown.
                             _inputEncoding = Encoding.UTF8;
                             _inputStream = Stream.Null;

--- a/Src/Microsoft.Scripting/Runtime/SharedIO.cs
+++ b/Src/Microsoft.Scripting/Runtime/SharedIO.cs
@@ -91,10 +91,11 @@ namespace Microsoft.Scripting.Runtime {
             if (_inputStream == null) {
                 lock (_mutex) {
                     if (_inputStream == null) {
+                        try {
 #if FEATURE_FULL_CONSOLE
-                        _inputStream = ConsoleInputStream.Instance;
-                        _inputEncoding = Console.InputEncoding;
-                        _inputReader = Console.In;
+                            _inputStream = ConsoleInputStream.Instance;
+                            _inputEncoding = Console.InputEncoding;
+                            _inputReader = Console.In;
 #elif FEATURE_BASIC_CONSOLE
                         _inputEncoding = Encoding.Default;
                         _inputStream = new TextStream(Console.In, _inputEncoding);
@@ -104,6 +105,11 @@ namespace Microsoft.Scripting.Runtime {
                         _inputStream = Stream.Null;
                         _inputReader = TextReader.Null;
 #endif
+                        } catch (TypeInitializationException) {
+                            _inputEncoding = Encoding.UTF8;
+                            _inputStream = Stream.Null;
+                            _inputReader = TextReader.Null;
+                        }
                     }
                 }
             }

--- a/Src/Microsoft.Scripting/Runtime/SharedIO.cs
+++ b/Src/Microsoft.Scripting/Runtime/SharedIO.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Scripting.Runtime {
                         _inputReader = TextReader.Null;
 #endif
                         } catch (TypeInitializationException) {
+                            // When on BlazorWebassembly, this exception is thrown.
                             _inputEncoding = Encoding.UTF8;
                             _inputStream = Stream.Null;
                             _inputReader = TextReader.Null;

--- a/Src/Microsoft.Scripting/Utils/ConsoleInputStream.cs
+++ b/Src/Microsoft.Scripting/Utils/ConsoleInputStream.cs
@@ -17,8 +17,16 @@ namespace Microsoft.Scripting.Utils {
     /// </summary>
     public sealed class ConsoleInputStream : Stream {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly ConsoleInputStream Instance = new ConsoleInputStream();
-        
+        private static ConsoleInputStream _instance = null;
+
+        public static ConsoleInputStream Instance {
+            // When there is no input stream available (e.g. BlazorWasm), propagate PlatformNotSupportedException
+            get {
+                if (_instance == null) _instance = new();
+                return _instance;
+            }
+        }
+
         // we use 0x1000 to be safe (MSVCRT uses this value for stdin stream buffer).
         private const int MinimalBufferSize = 0x1000; 
 


### PR DESCRIPTION
When trying to use IronPython3 from a Blazor web-assembly application, `Microsoft.Scripting.Runtime.SharedIO` throws an exception when trying to setup `stdin`, which is understandable, because there is none.

All I did is catch the exception and set the stream to `Stream.Null`.