### PR TITLE
Add GNU Readline keybindings in SuperConsole

### DIFF
--- a/Src/Microsoft.Dynamic/Hosting/Shell/SuperConsole.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/SuperConsole.cs
@@ -430,7 +430,7 @@ namespace Microsoft.Scripting.Hosting.Shell {
         private void MoveNextWordEnd() {
             // move to the next end-of-word position
             if (_input.Length != 0 && _current < _input.Length) {
-                bool nonLetter = IsSeparator(_input[Math.Min(_current + 1, _input.Length - 1)]);
+                bool nonLetter = IsSeparator(_input[_current]);
                 while (_current < _input.Length) {
                     MoveRight();
 


### PR DESCRIPTION
### Problem

The main motivation for this PR was terrible command-line editing experience on macOS. The existing keybindings for moving the cursor on the input line are _Home_/_End_ and _Ctrl-Left_/_Ctrl-Right_ (move to the beginning/end of line, begining of previous/next word respectively) are by default used by the macOS Terminal app (scrolling the output buffer, switching to other window instances). This leaves only the _Left_/_Right_ cursor keys for editing, which is quite inconvenient on longer lines.

### Solution

Many programs (bash, zsh, pwsh, python) on Linux and macOS adapt the GNU Readline convention, which is a subset of Emacs keybindings. Python's StdLib has even module `readline` to write interactive programs that support commandline editing using the GNU Readline keybindings. This PR adds support for the unavailable cursor movement operations on macOS by binding them to the GNU Readline control characters. Specifically:

New key | Original key | Meaning
-|-|-
Ctrl-A | Home | Move to the beginning of input line
Ctrl-E | End | Move to the end of input line
Meta-B | Ctrl-Left | Move back to the beginning of word
Meta-F | Ctrl-Right *1 | Move forward to the end of word

*1: Ctrl-Right actually moves forward to the beginning of the next word, not the end of the current word

The original keybindings stay in place, in case somebody reconfigured the Terminal app or uses a different terminal emulator that does not capture those keybindings (like VSCode).

The new keybindings are only enabled on Linux and macOS. More about it below.

### Extras

But since I was already at it, I added several other Emacs/Readline keybindings that duplicate the functionality that was already working. This is to support existing finger habits:

New key | Original key | Meaning
-|-|-
Ctrl-P | Up | Go to previous input line
Ctrl-N | Down | Go to next input line
Ctrl-B | Left | Kove back one character
Ctrl-F | Right | Move forward one character
Ctrl-K | Ctrl-End *2 | Delete the rest of line
Ctrl-U | Ctrl-Home *2 | Delete everything before the cursor
Ctrl-W | Alt-Backspace *2,3 |  Delete to the beginning of word
Ctrl-D *4 | Delete | Delete character at the cursor

*2: These are new keybindings too.
*3: On macOS, _Alt_ becomes _Meta_.
*4: This keybinding is overloaded, see below.

### Exit

Most (if not all) Unix tools use _Ctrl-D_ as end of input, which closes the console input stream immediately when given on an empty line (e,g, `cat`, `python`). It has been reported that IronPython requires an extra _Enter_ key after _Ctrl-D_ to terminate the interactive session (IronLanguages/ironpython3#1069, IronLanguages/ironpython2#156). Since this PR implements a keybinding for _Ctrl-D_, it also fixes that issue. _Ctrl-D_ on an empty input line terminates the session immediately.

### Windows

This PR is meant to improve the experience on macOS and Linux, so I deliberately tried to avoid changing the behaviour on Windows, but there are some exceptions and discussion points.

1. Keybindings marked with *2 in the tables above are new on Windows too. They are quite useful and some are fairly common on Windows too: _Ctrl-Home_/_Ctrl-End_ work in CMD, Python, and PowerShell. _Alt-Backspace_ is less common because it is basically a Readline keybinding. Which brings us to the next point.
2. Perhaps it would be useful to enable Readline keybindings on Windows too. I didn't do it because I didn't want to impact any legacy Windows apps using DLR, and also, because Standard Python doesn't support them (on Windows). However, PowerShell can be configured to use Readline keybindings on Windows (`Set-PSReadlineOption -EditMode Emacs`) which then extend to Anaconda Python. So I wonder if it would be a good idea to enable Readline keybindings in `SuperConsole` on Windows too.
3. The definition of a _word_, used for cursor movement and deletion has changed to match the existing Windows convention. See below.

### Word

A number of commands use a notion of a _word_, which brings up a question what a _word_ is. DLR used a definition that a word is a series of letter characters. This is a strange convention that I don't know of any other programming tool using. It also leads to some strange behaviour, for instance, expression `a = 4 / b`, when navigated by next/previous word, only jumps between  `a` and `b`.

Looking at other tools, I recognize the following three conventions. A _word_ is a contiguous sequence of:
1. Non-whitespace characters.
2. Alphanumeric characters,
3. Alphanumeric characters and an underscore.

Convention 1 is what Windows tools use by default, e.g. CMD, Python, Anaconda Python and PowerShell with `-EditMode Windows` (default). Hence this is the convention now used on Windows by `SuperConsole`.

Convention 2 is what Linux and macOS tools use, hence this is the convention adopted for `SuperConsole` on those platforms.

Convention 3 is what PowerShell uses with `-EditMode Emacs`. Also Anaconda Python, when started from PowerShell configured in this mode. Personally I find it the most useful, and this would be my choince if other Emacs keybindings became available on Windows.