### PR TITLE
Improve thread safety of HybridMappimg

### DIFF
--- a/Src/Microsoft.Dynamic/Utils/WeakDictionary.cs
+++ b/Src/Microsoft.Dynamic/Utils/WeakDictionary.cs
@@ -347,7 +347,12 @@ namespace Microsoft.Scripting.Utils {
         }
 
         public T GetObjectFromId(int id) {
-            if (_dict.TryGetValue(id, out object ret)) {
+            bool success;
+            object ret;
+            lock (_synchObject) {
+                success = _dict.TryGetValue(id, out ret);
+            }
+            if (success) {
                 if (ret is WeakObject weakObj) {
                     return (T)weakObj.Target;
                 }
@@ -393,10 +398,12 @@ namespace Microsoft.Scripting.Utils {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")] // TODO: fix
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")] // TODO: fix (rename?)
         public void RemoveOnObject(T value) {
-            try {
-                int id = GetIdFromObject(value);
-                RemoveOnId(id);
-            } catch { }
+            lock (_synchObject) {
+                try {
+                    int id = GetIdFromObject(value);
+                    RemoveOnId(id);
+                } catch { }
+            }
         }
     }
 }


### PR DESCRIPTION
Something I have noticed while working on IronLanguages/IronPython3#1711. I submit it for the sake of correctness; it seems I will not be using `HybridMapping` in `PythonFileManager` after all.