### PR TITLE
Fix option ColorfulConsole

### DIFF
--- a/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleHost.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleHost.cs
@@ -121,17 +121,17 @@ namespace Microsoft.Scripting.Hosting.Shell {
             ContractUtils.RequiresNotNull(options, nameof(options));
 
             if (options.TabCompletion) {
-                return CreateSuperConsole(commandLine, options.ColorfulConsole);
+                return CreateSuperConsole(commandLine, options);
             }
 
-            return new BasicConsole(options.ColorfulConsole);
+            return new BasicConsole(options);
         }
 
         // The advanced console functions are in a special non-inlined function so that 
         // dependencies are pulled in only if necessary.
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        private static IConsole CreateSuperConsole(CommandLine commandLine, bool isColorful) {
-            return new SuperConsole(commandLine, isColorful);
+        private static IConsole CreateSuperConsole(CommandLine commandLine, ConsoleOptions options) {
+            return new SuperConsole(commandLine, options);
         }
 
         #endregion

--- a/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleOptions.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleOptions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Scripting.Hosting.Shell {
         private bool _handleExceptions = true;
         private bool _tabCompletion;
         private bool _colorfulConsole;
+        private bool? _darkConsole;
         private bool _printUsage;
         private bool _isMta;
 #if FEATURE_REMOTING
@@ -46,6 +47,15 @@ namespace Microsoft.Scripting.Hosting.Shell {
         public bool ColorfulConsole {
             get { return _colorfulConsole; }
             set { _colorfulConsole = value; }
+        }
+
+        /// <summary>
+        /// If ColorfulConsole is used, indicate preference for using a color scheme for a console with a dark background.
+        /// Value <c>null</c> means no preference (use autodetect if possible).
+        /// </summary>
+        public bool? DarkConsole {
+            get { return _darkConsole; }
+            set { _darkConsole = value; }
         }
 
         public bool PrintUsage {
@@ -127,6 +137,7 @@ namespace Microsoft.Scripting.Hosting.Shell {
             _handleExceptions = options._handleExceptions;
             _tabCompletion = options._tabCompletion;
             _colorfulConsole = options._colorfulConsole;
+            _darkConsole = options._darkConsole;
             _printUsage = options._printUsage;
             _isMta = options._isMta;
 #if FEATURE_REMOTING

--- a/Src/Microsoft.Dynamic/Hosting/Shell/OptionsParser.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/OptionsParser.cs
@@ -180,7 +180,6 @@ namespace Microsoft.Scripting.Hosting.Shell {
                 case "-X:PrivateBinding":
                 case "-X:PassExceptions":
                 // TODO: #if !IRONPYTHON_WINDOW
-                case "-X:ColorfulConsole":
                 case "-X:TabCompletion":
                 case "-X:AutoIndent":
                 // #endif
@@ -197,6 +196,7 @@ namespace Microsoft.Scripting.Hosting.Shell {
 #if DEBUG
                 case "-X:PerfStats":
 #endif
+                    // Option without argument
                     HandleImplementationSpecificOption(arg.Substring(3), null);
                     break;
 
@@ -207,11 +207,21 @@ namespace Microsoft.Scripting.Hosting.Shell {
 #if FEATURE_REMOTING
                 case "-X:" + Remote.RemoteRuntimeServer.RemoteRuntimeArg:
 #endif
+                    // Option with mandatory argument
                     HandleImplementationSpecificOption(arg.Substring(3), PopNextArg());
                     break;
 
                 default:
-                    ConsoleOptions.FileName = arg.Trim();
+                    string[] split = arg.Split(new[] { '=' }, 2);
+                    switch (split[0]) {
+                        case "-X:ColorfulConsole":
+                            // Option with optional argument
+                            HandleImplementationSpecificOption(split[0].Substring(3), split.Length > 1 ? split[1] : null);
+                            break;
+                        default:
+                            ConsoleOptions.FileName = arg.Trim();
+                            break;
+                    }
                     break;
             }
         }

--- a/Src/Microsoft.Dynamic/Hosting/Shell/OptionsParser.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/OptionsParser.cs
@@ -230,6 +230,12 @@ namespace Microsoft.Scripting.Hosting.Shell {
 
                 case "ColorfulConsole":
                     ConsoleOptions.ColorfulConsole = true;
+                    ConsoleOptions.DarkConsole = val switch {
+                        "dark" => true,
+                        "light" => false,
+                        null => null,
+                        _ => throw new InvalidOptionException($"Argument for -X:{arg} option must be \"dark\" or \"light\".")
+                    };
                     break;
 
                 case "TabCompletion":
@@ -327,7 +333,8 @@ namespace Microsoft.Scripting.Hosting.Shell {
                 { "-X:PrivateBinding",           "Enable binding to private members" },
                 { "-X:ShowClrExceptions",        "Display CLS Exception information" },
                 { "-X:TabCompletion",            "Enable TabCompletion mode" },
-                { "-X:ColorfulConsole",          "Enable ColorfulConsole" },
+                { "-X:ColorfulConsole[=(dark|light)]",
+                                                 "Enable ColorfulConsole (on dark or light background)" },
 #if DEBUG
                 { "-X:AssembliesDir <dir>",      "Set the directory for saving generated assemblies [debug only]" },
                 { "-X:SaveAssemblies",           "Save generated assemblies [debug only]" },

--- a/Src/Microsoft.Dynamic/Hosting/Shell/SuperConsole.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/SuperConsole.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Scripting.Hosting.Shell {
         private int _current;
 
         /// <summary>
-        /// The number of white-spaces displayed for the auto-indenation of the current line
+        /// The number of white-spaces displayed for the auto-indentation of the current line
         /// </summary>
         private int _autoIndentSize;
 
@@ -190,7 +190,7 @@ namespace Microsoft.Scripting.Hosting.Shell {
         private SuperConsoleOptions _options = new SuperConsoleOptions();
 
         /// <summary>
-        /// Cursort anchor - position of cursor when the routine was called
+        /// Cursor anchor - position of cursor when the routine was called
         /// </summary>
         private Cursor _cursor;
 
@@ -204,11 +204,15 @@ namespace Microsoft.Scripting.Hosting.Shell {
         /// </summary>
         private EditMode _editMode;
 
-        public SuperConsole(CommandLine commandLine, bool colorful)
-            : base(colorful) {
+        public SuperConsole(CommandLine commandLine, ConsoleOptions options)
+            : base(options) {
             ContractUtils.RequiresNotNull(commandLine, nameof(commandLine));
             _commandLine = commandLine;
             _editMode = Environment.OSVersion.Platform == PlatformID.Unix ? EditMode.Emacs : EditMode.Windows;
+        }
+
+        public SuperConsole(CommandLine commandLine, bool colorful)
+            : this(commandLine, new ConsoleOptions() { ColorfulConsole = colorful }) {
         }
 
         public SuperConsole(CommandLine commandLine, bool colorful, EditMode editMode)


### PR DESCRIPTION
Option `-X ColorfulConsole` was not working, for several reasons:

1. The fag mask used to set colors was incorrect, resulting all colors be coerced to either white or black.
2. The fallback color was white, which for white background always resulted in the text being invisible (macOS default console has white background).
3. The background detection was working only on Windows, on Unix, the background color is unknown. So to make this option usable on Unix systems, I extended it with an optional parameter of value _dark_ or _light_. To prevent proliferation of constructor parameters and the number of constructors of `BasicConsole` and `SuperConsole`, they both got a constructor that accepts `ConsoleOptions` and picks up the option it can understand.