### PR TITLE
Make BASIC and FULL console support runtime-selectable if both available

### DIFF
--- a/Build/net452.props
+++ b/Build/net452.props
@@ -16,7 +16,6 @@
     <Features>$(Features);FEATURE_CUSTOM_TYPE_DESCRIPTOR</Features>
     <Features>$(Features);FEATURE_EXCEPTION_STATE</Features>
     <Features>$(Features);FEATURE_FILESYSTEM</Features>
-    <Features>$(Features);FEATURE_FULL_CONSOLE</Features>
     <Features>$(Features);FEATURE_FULL_CRYPTO</Features>
     <Features>$(Features);FEATURE_FULL_NET</Features>
     <Features>$(Features);FEATURE_LAMBDAEXPRESSION_COMPILETOMETHOD</Features>

--- a/Build/net452.props
+++ b/Build/net452.props
@@ -9,7 +9,6 @@
     <Features>$(Features);FEATURE_ASSEMBLY_RESOLVE</Features>
     <Features>$(Features);FEATURE_ASSEMBLYBUILDER_DEFINEDYNAMICASSEMBLY</Features>
     <Features>$(Features);FEATURE_ASSEMBLYBUILDER_SAVE</Features>
-    <Features>$(Features);FEATURE_BASIC_CONSOLE</Features>
     <Features>$(Features);FEATURE_CODEDOM</Features>
     <Features>$(Features);FEATURE_COM</Features>
     <Features>$(Features);FEATURE_CONFIGURATION</Features>

--- a/Build/net6.0.props
+++ b/Build/net6.0.props
@@ -9,7 +9,6 @@
     <Features>$(Features);FEATURE_ASSEMBLY_GETFORWARDEDTYPES</Features>
     <Features>$(Features);FEATURE_ASSEMBLY_RESOLVE</Features>
     <Features>$(Features);FEATURE_ASSEMBLYBUILDER_DEFINEDYNAMICASSEMBLY</Features>
-    <Features>$(Features);FEATURE_BASIC_CONSOLE</Features>
     <Features>$(Features);FEATURE_CODEDOM</Features>
     <Features>$(Features);FEATURE_COM</Features>
     <Features>$(Features);FEATURE_CONFIGURATION</Features>

--- a/Build/net6.0.props
+++ b/Build/net6.0.props
@@ -16,7 +16,6 @@
     <Features>$(Features);FEATURE_CUSTOM_TYPE_DESCRIPTOR</Features>
     <Features>$(Features);FEATURE_EXCEPTION_STATE</Features>
     <Features>$(Features);FEATURE_FILESYSTEM</Features>
-    <Features>$(Features);FEATURE_FULL_CONSOLE</Features>
     <Features>$(Features);FEATURE_FULL_CRYPTO</Features>
     <Features>$(Features);FEATURE_FULL_NET</Features>
     <Features>$(Features);FEATURE_LCG</Features>

--- a/Build/netcoreapp3.1.props
+++ b/Build/netcoreapp3.1.props
@@ -9,7 +9,6 @@
     <Features>$(Features);FEATURE_ASSEMBLY_GETFORWARDEDTYPES</Features>
     <Features>$(Features);FEATURE_ASSEMBLY_RESOLVE</Features>
     <Features>$(Features);FEATURE_ASSEMBLYBUILDER_DEFINEDYNAMICASSEMBLY</Features>
-    <Features>$(Features);FEATURE_BASIC_CONSOLE</Features>
     <Features>$(Features);FEATURE_CODEDOM</Features>
     <Features>$(Features);FEATURE_COM</Features>
     <Features>$(Features);FEATURE_CONFIGURATION</Features>

--- a/Build/netcoreapp3.1.props
+++ b/Build/netcoreapp3.1.props
@@ -16,7 +16,6 @@
     <Features>$(Features);FEATURE_CUSTOM_TYPE_DESCRIPTOR</Features>
     <Features>$(Features);FEATURE_EXCEPTION_STATE</Features>
     <Features>$(Features);FEATURE_FILESYSTEM</Features>
-    <Features>$(Features);FEATURE_FULL_CONSOLE</Features>
     <Features>$(Features);FEATURE_FULL_CRYPTO</Features>
     <Features>$(Features);FEATURE_FULL_NET</Features>
     <Features>$(Features);FEATURE_LCG</Features>

--- a/Build/netstandard2.0.props
+++ b/Build/netstandard2.0.props
@@ -8,7 +8,6 @@
     <Features>$(Features);FEATURE_APARTMENTSTATE</Features>
     <Features>$(Features);FEATURE_ASSEMBLY_RESOLVE</Features>
     <Features>$(Features);FEATURE_ASSEMBLYBUILDER_DEFINEDYNAMICASSEMBLY</Features>
-    <Features>$(Features);FEATURE_BASIC_CONSOLE</Features>
     <Features>$(Features);FEATURE_CODEDOM</Features>
     <Features>$(Features);FEATURE_CONFIGURATION</Features>
     <Features>$(Features);FEATURE_CUSTOM_TYPE_DESCRIPTOR</Features>

--- a/Build/netstandard2.0.props
+++ b/Build/netstandard2.0.props
@@ -14,7 +14,6 @@
     <Features>$(Features);FEATURE_CUSTOM_TYPE_DESCRIPTOR</Features>
     <Features>$(Features);FEATURE_EXCEPTION_STATE</Features>
     <Features>$(Features);FEATURE_FILESYSTEM</Features>
-    <Features>$(Features);FEATURE_FULL_CONSOLE</Features>
     <Features>$(Features);FEATURE_FULL_CRYPTO</Features>
     <Features>$(Features);FEATURE_FULL_NET</Features>
     <Features>$(Features);FEATURE_LCG</Features>

--- a/Src/Microsoft.Dynamic/Hosting/Shell/BasicConsole.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/BasicConsole.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_FULL_CONSOLE
-
 using System;
 using System.IO;
 using System.Threading;
@@ -182,5 +180,3 @@ namespace Microsoft.Scripting.Hosting.Shell {
         #endregion
     }
 }
-
-#endif

--- a/Src/Microsoft.Dynamic/Hosting/Shell/CommandLine.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/CommandLine.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_FULL_CONSOLE
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -444,4 +442,3 @@ namespace Microsoft.Scripting.Hosting.Shell {
     }
 
 }
-#endif

--- a/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleHost.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleHost.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_FULL_CONSOLE
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -449,5 +447,3 @@ namespace Microsoft.Scripting.Hosting.Shell {
         }
     }
 }
-
-#endif

--- a/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleHostOptions.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleHostOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_FULL_CONSOLE
-
 using System.Collections.Generic;
 using Microsoft.Scripting.Utils;
 using System.Reflection;
@@ -39,4 +37,3 @@ namespace Microsoft.Scripting.Hosting.Shell {
         }
     }
 }
-#endif

--- a/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleHostOptionsParser.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleHostOptionsParser.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_FULL_CONSOLE
-
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -129,5 +127,3 @@ namespace Microsoft.Scripting.Hosting.Shell {
         }
     }
 }
-
-#endif

--- a/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleOptions.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/ConsoleOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_FULL_CONSOLE
-
 using System;
 using Microsoft.Scripting.Utils;
 
@@ -135,5 +133,3 @@ namespace Microsoft.Scripting.Hosting.Shell {
         }
     }
 }
-
-#endif

--- a/Src/Microsoft.Dynamic/Hosting/Shell/IConsole.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/IConsole.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_FULL_CONSOLE
-
 using System.IO;
 
 namespace Microsoft.Scripting.Hosting.Shell {
@@ -33,5 +31,3 @@ namespace Microsoft.Scripting.Hosting.Shell {
         TextWriter ErrorOutput { get; set; }
     }
 }
-
-#endif

--- a/Src/Microsoft.Dynamic/Hosting/Shell/OptionsParser.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/OptionsParser.cs
@@ -47,11 +47,10 @@ namespace Microsoft.Scripting.Hosting.Shell {
             get { return _platform; }
         }
 
-#if FEATURE_FULL_CONSOLE
         public abstract ConsoleOptions CommonConsoleOptions {
             get;
         }
-#endif
+
         public IList<string> IgnoredArgs {
             get { return _ignoredArgs; }
         }
@@ -129,7 +128,6 @@ namespace Microsoft.Scripting.Hosting.Shell {
         public abstract void GetHelp(out string commandLine, out string[,] options, out string[,] environmentVariables, out string comments);
     }
 
-#if FEATURE_FULL_CONSOLE
     public class OptionsParser<TConsoleOptions> : OptionsParser
         where TConsoleOptions : ConsoleOptions, new() {
 
@@ -345,5 +343,4 @@ namespace Microsoft.Scripting.Hosting.Shell {
             comments = null;
         }
     }
-#endif
 }

--- a/Src/Microsoft.Dynamic/Hosting/Shell/Remote/ConsoleRestartManager.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/Remote/ConsoleRestartManager.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_REMOTING && FEATURE_FULL_CONSOLE
+#if FEATURE_REMOTING
 
 using System;
 using System.Collections.Generic;
@@ -18,7 +18,7 @@ namespace Microsoft.Scripting.Hosting.Shell.Remote {
     /// Threading model:
     /// 
     /// ConsoleRestartManager creates a separate thread on which to create and execute the consoles. 
-    /// There are usually atleast three threads involved:
+    /// There are usually at least three threads involved:
     /// 
     /// 1. Main app thread: Instantiates ConsoleRestartManager and accesses its APIs. This thread has to stay 
     ///    responsive to user input and so the ConsoleRestartManager APIs cannot be long-running or blocking.
@@ -45,7 +45,7 @@ namespace Microsoft.Scripting.Hosting.Shell.Remote {
     /// 3. CompletionPort async callbacks:
     ///        Process.Exited | Process.OutputDataReceived | Process.ErrorDataReceived
     /// 
-    /// 4. Finalizer thred
+    /// 4. Finalizer thread
     ///    Some objects may have a Finalize method (which possibly calls Dispose). Not many (if any) types
     ///    should have a Finalize method.
     /// 

--- a/Src/Microsoft.Dynamic/Hosting/Shell/Remote/RemoteCommandDispatcher.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/Remote/RemoteCommandDispatcher.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_REMOTING && FEATURE_FULL_CONSOLE
+#if FEATURE_REMOTING
 
 using System;
 using System.Diagnostics;

--- a/Src/Microsoft.Dynamic/Hosting/Shell/Remote/RemoteConsoleCommandLine.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/Remote/RemoteConsoleCommandLine.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_REMOTING && FEATURE_FULL_CONSOLE
+#if FEATURE_REMOTING
 
 using System;
 using System.Diagnostics;

--- a/Src/Microsoft.Dynamic/Hosting/Shell/Remote/RemoteConsoleHost.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/Remote/RemoteConsoleHost.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_REMOTING && FEATURE_FULL_CONSOLE
+#if FEATURE_REMOTING
 
 using System;
 using System.Diagnostics;

--- a/Src/Microsoft.Dynamic/Hosting/Shell/Remote/RemoteRuntimeServer.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/Remote/RemoteRuntimeServer.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_REMOTING && FEATURE_FULL_CONSOLE
+#if FEATURE_REMOTING
 
 using System;
 using System.Diagnostics;

--- a/Src/Microsoft.Dynamic/Hosting/Shell/SuperConsole.cs
+++ b/Src/Microsoft.Dynamic/Hosting/Shell/SuperConsole.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_FULL_CONSOLE
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -287,7 +285,7 @@ namespace Microsoft.Scripting.Hosting.Shell {
 
         // Check if the user is backspacing the auto-indentation. In that case, we go back all the way to
         // the previous indentation level.
-        // Return true if we did backspace the auto-indenation.
+        // Return true if we did backspace the auto-indentation.
         private bool BackspaceAutoIndentation() {
             if (_input.Length == 0 || _input.Length > _autoIndentSize) return false;
 
@@ -748,4 +746,3 @@ namespace Microsoft.Scripting.Hosting.Shell {
         }
     }
 }
-#endif

--- a/Src/Microsoft.Dynamic/PerfTrack.cs
+++ b/Src/Microsoft.Dynamic/PerfTrack.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Scripting {
             return result;
         }
 
-#if FEATURE_BASIC_CONSOLE
         public static void DumpHistogram<TKey>(IDictionary<TKey, int> histogram) {
             DumpHistogram(histogram, Console.Out);
         }
@@ -71,7 +70,6 @@ namespace Microsoft.Scripting {
         public static void DumpStats() {
             DumpStats(Console.Out);
         }
-#endif
 
         public static void DumpHistogram<TKey>(IDictionary<TKey, int> histogram, TextWriter output) {
             var keys = ArrayUtils.MakeArray(histogram.Keys);

--- a/Src/Microsoft.Scripting/Runtime/SharedIO.cs
+++ b/Src/Microsoft.Scripting/Runtime/SharedIO.cs
@@ -84,6 +84,10 @@ namespace Microsoft.Scripting.Runtime {
         public Encoding OutputEncoding { get { InitializeOutput(); return _outputWriter.Encoding; } }
         public Encoding ErrorEncoding { get { InitializeErrorOutput(); return _errorWriter.Encoding; } }
 
+#if FEATURE_FULL_CONSOLE && FEATURE_BASIC_CONSOLE
+        public bool PreferBasicIO { get; set; }
+#endif
+
         internal SharedIO() {
         }
 
@@ -93,14 +97,22 @@ namespace Microsoft.Scripting.Runtime {
                     if (_inputStream == null) {
                         try {
 #if FEATURE_FULL_CONSOLE
-                            _inputStream = ConsoleInputStream.Instance;
-                            _inputEncoding = Console.InputEncoding;
-                            _inputReader = Console.In;
-#elif FEATURE_BASIC_CONSOLE
+    #if FEATURE_BASIC_CONSOLE
+                            if (!PreferBasicIO) {
+    #endif
+                                _inputEncoding = Console.InputEncoding;
+                                _inputStream = ConsoleInputStream.Instance;
+                                _inputReader = Console.In;
+    #if FEATURE_BASIC_CONSOLE
+                                return;
+                            }
+    #endif
+#endif
+#if FEATURE_BASIC_CONSOLE
                             _inputEncoding = Encoding.Default;
                             _inputStream = new TextStream(Console.In, _inputEncoding);
                             _inputReader = Console.In;
-#else
+#elif !FEATURE_FULL_CONSOLE
                             _inputEncoding = Encoding.UTF8;
                             _inputStream = Stream.Null;
                             _inputReader = TextReader.Null;
@@ -121,12 +133,20 @@ namespace Microsoft.Scripting.Runtime {
                 lock (_mutex) {
                     if (_outputStream == null) {
 #if FEATURE_FULL_CONSOLE
-                        _outputStream = Console.OpenStandardOutput();
-                        _outputWriter = Console.Out;
-#elif FEATURE_BASIC_CONSOLE
+    #if FEATURE_BASIC_CONSOLE
+                        if (!PreferBasicIO) {
+    #endif
+                            _outputStream = Console.OpenStandardOutput();
+                            _outputWriter = Console.Out;
+    #if FEATURE_BASIC_CONSOLE
+                            return;
+                        }
+    #endif
+#endif
+#if FEATURE_BASIC_CONSOLE
                         _outputStream = new TextStream(Console.Out);
                         _outputWriter = Console.Out;
-#else
+#elif !FEATURE_FULL_CONSOLE
                         _outputStream = Stream.Null;
                         _outputWriter = TextWriter.Null;
 #endif
@@ -140,12 +160,20 @@ namespace Microsoft.Scripting.Runtime {
                 lock (_mutex) {
                     if (_errorStream == null) {
 #if FEATURE_FULL_CONSOLE
-                        _errorStream = Console.OpenStandardError();
-                        _errorWriter = Console.Error;
-#elif FEATURE_BASIC_CONSOLE
+    #if FEATURE_BASIC_CONSOLE
+                        if (!PreferBasicIO) {
+    #endif
+                            _errorStream = Console.OpenStandardError();
+                            _errorWriter = Console.Error;
+    #if FEATURE_BASIC_CONSOLE
+                            return;
+                        }
+    #endif
+#endif
+#if FEATURE_BASIC_CONSOLE
                         _errorStream =  new TextStream(Console.Error);
                         _errorWriter = Console.Error;
-#else
+#elif !FEATURE_FULL_CONSOLE
                         _errorStream = Stream.Null;
                         _errorWriter = TextWriter.Null;
 #endif

--- a/Src/Microsoft.Scripting/Runtime/SharedIO.cs
+++ b/Src/Microsoft.Scripting/Runtime/SharedIO.cs
@@ -139,7 +139,9 @@ namespace Microsoft.Scripting.Runtime {
                             case SupportLevel.None:
                             default:
                                 _outputStream = Stream.Null;
-                                _outputWriter = new StreamWriter(_outputStream, Encoding.UTF8, bufferSize: 16);
+                                _outputWriter = TextWriter.Null.Encoding.CodePage is 1200 or 65001
+                                    ? TextWriter.Null // uses UTF-16LE or UTF-8
+                                    : new StreamWriter(_outputStream, Encoding.Unicode, bufferSize: 64);
                                 break;
                         }
                     }
@@ -163,7 +165,9 @@ namespace Microsoft.Scripting.Runtime {
                             case SupportLevel.None:
                             default:
                                 _errorStream = Stream.Null;
-                                _errorWriter = new StreamWriter(_errorStream, Encoding.UTF8, bufferSize: 16);
+                                _errorWriter = TextWriter.Null.Encoding.CodePage is 1200 or 65001
+                                    ? TextWriter.Null // uses UTF-16LE or UTF-8
+                                    : new StreamWriter(_errorStream, Encoding.Unicode, bufferSize: 64);
                                 break;
                         }
                     }

--- a/Src/Microsoft.Scripting/Runtime/SharedIO.cs
+++ b/Src/Microsoft.Scripting/Runtime/SharedIO.cs
@@ -10,6 +10,13 @@ using Microsoft.Scripting.Utils;
 
 namespace Microsoft.Scripting.Runtime {
     public sealed class SharedIO {
+
+        public enum SupportLevel {
+            None,
+            Basic,
+            Full,
+        }
+
         // prevents this object from transitions to an inconsistent state, doesn't sync output or input:
         private readonly object _mutex = new object();
 
@@ -84,9 +91,7 @@ namespace Microsoft.Scripting.Runtime {
         public Encoding OutputEncoding { get { InitializeOutput(); return _outputWriter.Encoding; } }
         public Encoding ErrorEncoding { get { InitializeErrorOutput(); return _errorWriter.Encoding; } }
 
-#if FEATURE_FULL_CONSOLE && FEATURE_BASIC_CONSOLE
-        public bool PreferBasicIO { get; set; }
-#endif
+        public SupportLevel ConsoleSupportLevel { get; set; } = SupportLevel.Full;
 
         internal SharedIO() {
         }
@@ -95,33 +100,23 @@ namespace Microsoft.Scripting.Runtime {
             if (_inputStream == null) {
                 lock (_mutex) {
                     if (_inputStream == null) {
-                        try {
-#if FEATURE_FULL_CONSOLE
-    #if FEATURE_BASIC_CONSOLE
-                            if (!PreferBasicIO) {
-    #endif
+                        switch (ConsoleSupportLevel) {
+                            case SupportLevel.Full:
                                 _inputEncoding = Console.InputEncoding;
                                 _inputStream = ConsoleInputStream.Instance;
                                 _inputReader = Console.In;
-    #if FEATURE_BASIC_CONSOLE
-                                return;
-                            }
-    #endif
-#endif
-#if FEATURE_BASIC_CONSOLE
-                            _inputEncoding = Encoding.Default;
-                            _inputStream = new TextStream(Console.In, _inputEncoding);
-                            _inputReader = Console.In;
-#elif !FEATURE_FULL_CONSOLE
-                            _inputEncoding = Encoding.UTF8;
-                            _inputStream = Stream.Null;
-                            _inputReader = TextReader.Null;
-#endif
-                        } catch (PlatformNotSupportedException) {
-                            // When on BlazorWebassembly, this exception is thrown.
-                            _inputEncoding = Encoding.UTF8;
-                            _inputStream = Stream.Null;
-                            _inputReader = TextReader.Null;
+                                break;
+                            case SupportLevel.Basic:
+                                _inputEncoding = Encoding.UTF8;
+                                _inputStream = new TextStream(Console.In, _inputEncoding);
+                                _inputReader = Console.In;
+                                break;
+                            case SupportLevel.None:
+                            default:
+                                _inputEncoding = Encoding.UTF8;
+                                _inputStream = Stream.Null;
+                                _inputReader = TextReader.Null;
+                                break;
                         }
                     }
                 }
@@ -132,24 +127,21 @@ namespace Microsoft.Scripting.Runtime {
             if (_outputStream == null) {
                 lock (_mutex) {
                     if (_outputStream == null) {
-#if FEATURE_FULL_CONSOLE
-    #if FEATURE_BASIC_CONSOLE
-                        if (!PreferBasicIO) {
-    #endif
-                            _outputStream = Console.OpenStandardOutput();
-                            _outputWriter = Console.Out;
-    #if FEATURE_BASIC_CONSOLE
-                            return;
+                        switch (ConsoleSupportLevel) {
+                            case SupportLevel.Full:
+                                _outputStream = Console.OpenStandardOutput();
+                                _outputWriter = Console.Out;
+                                break;
+                            case SupportLevel.Basic:
+                                _outputStream = new TextStream(Console.Out);
+                                _outputWriter = Console.Out;
+                                break;
+                            case SupportLevel.None:
+                            default:
+                                _outputStream = Stream.Null;
+                                _outputWriter = new StreamWriter(_outputStream, Encoding.UTF8, bufferSize: 16);
+                                break;
                         }
-    #endif
-#endif
-#if FEATURE_BASIC_CONSOLE
-                        _outputStream = new TextStream(Console.Out);
-                        _outputWriter = Console.Out;
-#elif !FEATURE_FULL_CONSOLE
-                        _outputStream = Stream.Null;
-                        _outputWriter = TextWriter.Null;
-#endif
                     }
                 }
             }
@@ -159,26 +151,22 @@ namespace Microsoft.Scripting.Runtime {
             if (_errorStream == null) {
                 lock (_mutex) {
                     if (_errorStream == null) {
-#if FEATURE_FULL_CONSOLE
-    #if FEATURE_BASIC_CONSOLE
-                        if (!PreferBasicIO) {
-    #endif
-                            _errorStream = Console.OpenStandardError();
-                            _errorWriter = Console.Error;
-    #if FEATURE_BASIC_CONSOLE
-                            return;
+                        switch (ConsoleSupportLevel) {
+                            case SupportLevel.Full:
+                                _errorStream = Console.OpenStandardError();
+                                _errorWriter = Console.Error;
+                                break;
+                            case SupportLevel.Basic:
+                                _errorStream = new TextStream(Console.Error);
+                                _errorWriter = Console.Error;
+                                break;
+                            case SupportLevel.None:
+                            default:
+                                _errorStream = Stream.Null;
+                                _errorWriter = new StreamWriter(_errorStream, Encoding.UTF8, bufferSize: 16);
+                                break;
                         }
-    #endif
-#endif
-#if FEATURE_BASIC_CONSOLE
-                        _errorStream =  new TextStream(Console.Error);
-                        _errorWriter = Console.Error;
-#elif !FEATURE_FULL_CONSOLE
-                        _errorStream = Stream.Null;
-                        _errorWriter = TextWriter.Null;
-#endif
                     }
-
                 }
             }
         }

--- a/Src/Microsoft.Scripting/Utils/ConsoleInputStream.cs
+++ b/Src/Microsoft.Scripting/Utils/ConsoleInputStream.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_FULL_CONSOLE
-
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -110,4 +108,3 @@ namespace Microsoft.Scripting.Utils {
         #endregion
     }
 }
-#endif

--- a/Src/Microsoft.Scripting/Utils/TextStream.cs
+++ b/Src/Microsoft.Scripting/Utils/TextStream.cs
@@ -13,8 +13,6 @@
  *
  * ***************************************************************************/
 
-#if FEATURE_BASIC_CONSOLE // see SharedIO
-
 using System;
 using System.IO;
 using System.Text;
@@ -136,5 +134,3 @@ namespace Microsoft.Scripting.Utils {
 
 
 }
-
-#endif


### PR DESCRIPTION
The level of console support is selectable at build time through compile symbols `FEATURE_FULL_CONSOLE` and `FEATURE_BASIC_CONSOLE`.

1. When `FEATURE_FULL_CONSOLE` is defined, standard IO is performed using .NET console streams. This option is preferable for a standalone `ipy` program.
2. When `FEATURE_BASIC_CONSOLE` is defined, standard IO is performed using console reader/writer. This option may be preferable in some embedded cases when the hosting source code is not available and performs its own redirection (like _LinqPad_).
3. When neither is defined, standard IO is silently discarded.
4. When both are defined at the same time, the current code defaults to using .NET console streams.

The last case is interesting because this is the build feature set that is available on NuGet. The change proposed here makes the selection between using console streams and console reader/writer available at runtime, in case both relevant compile symbols were defined during the build. In this way, IronPython from NuGet could be configured for the embedded scenario in a simple way, like with a runtime option.