### PR TITLE
Add detection of standard IO streams

### DIFF
--- a/Src/Microsoft.Scripting/Runtime/SharedIO.cs
+++ b/Src/Microsoft.Scripting/Runtime/SharedIO.cs
@@ -233,5 +233,9 @@ namespace Microsoft.Scripting.Runtime {
         public Stream GetStreamProxy(ConsoleStreamType type) {
             return new StreamProxy(this, type);
         }
+
+        public static bool IsConsoleStream(Stream stream) {
+            return stream is StreamProxy;
+        }
     }
 }


### PR DESCRIPTION
I plan to use this test to protect standard file descriptors from accidental closure, when closing a Python file object (`FileIO`) using those descriptors. See also IronLanguages/ironpython3#1711.