### PR TITLE
Avoid ToLoverInvariant in string comparisons (CA1862)

### DIFF
--- a/Src/Microsoft.Dynamic/DebugOptions.cs
+++ b/Src/Microsoft.Dynamic/DebugOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Scripting {
 
         private static bool ReadOption(string name) {
             string envVar = ReadString(name);
-            return envVar != null && envVar.ToLowerInvariant() == "true";
+            return "true".Equals(envVar, StringComparison.InvariantCultureIgnoreCase);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "name")]

--- a/Src/Microsoft.Dynamic/DebugOptions.cs
+++ b/Src/Microsoft.Dynamic/DebugOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Scripting {
 
         private static bool ReadOption(string name) {
             string envVar = ReadString(name);
-            return "true".Equals(envVar, StringComparison.InvariantCultureIgnoreCase);
+            return "true".Equals(envVar, StringComparison.OrdinalIgnoreCase);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "name")]

--- a/Src/Microsoft.Dynamic/Generation/AssemblyGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/AssemblyGen.cs
@@ -283,7 +283,8 @@ namespace Microsoft.Scripting.Generation {
                 string toFile = Path.Combine(to, fi.Name);
                 FileInfo toInfo = new FileInfo(toFile);
 
-                if (fi.Extension.ToLowerInvariant() == ".dll" || fi.Extension.ToLowerInvariant() == ".exe") {
+                if (fi.Extension.Equals(".dll", StringComparison.InvariantCultureIgnoreCase)
+                    || fi.Extension.Equals(".exe", StringComparison.InvariantCultureIgnoreCase)) {
                     if (!File.Exists(toFile) || toInfo.CreationTime != fi.CreationTime) {
                         try {
                             File.Copy(filename, toFile, true);

--- a/Src/Microsoft.Dynamic/Generation/AssemblyGen.cs
+++ b/Src/Microsoft.Dynamic/Generation/AssemblyGen.cs
@@ -283,8 +283,8 @@ namespace Microsoft.Scripting.Generation {
                 string toFile = Path.Combine(to, fi.Name);
                 FileInfo toInfo = new FileInfo(toFile);
 
-                if (fi.Extension.Equals(".dll", StringComparison.InvariantCultureIgnoreCase)
-                    || fi.Extension.Equals(".exe", StringComparison.InvariantCultureIgnoreCase)) {
+                if (fi.Extension.Equals(".dll", StringComparison.OrdinalIgnoreCase)
+                    || fi.Extension.Equals(".exe", StringComparison.OrdinalIgnoreCase)) {
                     if (!File.Exists(toFile) || toInfo.CreationTime != fi.CreationTime) {
                         try {
                             File.Copy(filename, toFile, true);


### PR DESCRIPTION
Resolves some warnings-turned-errors.