### PR TITLE
Fix for missing trace event on first expression

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,21 +13,21 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest-large]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '3.1.x'
     - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x'
     - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
     - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '9.0.x'
         include-prerelease: true
@@ -35,7 +35,7 @@ jobs:
       run: pwsh make.ps1
     - name: Package
       run: pwsh make.ps1 package
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: packages
         path: Package/Release/Packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       run: pwsh make.ps1 package
     - uses: actions/upload-artifact@v4
       with:
-        name: packages
+        name: packages-${{ matrix.os }}
         path: Package/Release/Packages
     - name: Test (net462)
       run: ./make.ps1 -frameworks net462 test-all

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -94,7 +94,7 @@
 
   <!-- Release -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <DebugSymbols>false</DebugSymbols>
+    <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>

--- a/Src/Microsoft.Dynamic/Debugging/DebugInfoRewriter.cs
+++ b/Src/Microsoft.Dynamic/Debugging/DebugInfoRewriter.cs
@@ -17,7 +17,7 @@ using AstUtils = Microsoft.Scripting.Ast.Utils;
 namespace Microsoft.Scripting.Debugging {
     using Ast = MSAst.Expression;
     using System.Threading;
-    
+
     /// <summary>
     /// Used to rewrite expressions containing DebugInfoExpressions.
     /// </summary>
@@ -355,17 +355,12 @@ namespace Microsoft.Scripting.Debugging {
                 // Update the location cookie
                 int locationCookie = _locationCookie++;
                 if (!_transformToGenerator) {
-                    MSAst.Expression tracebackCall = null;
-                    if (locationCookie == 0) {
-                        tracebackCall = Ast.Empty();
-                    } else {
-                        tracebackCall = Ast.Call(
-                            typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.OnTraceEvent)),
-                            _thread,
-                            AstUtils.Constant(locationCookie),
-                            Ast.Convert(Ast.Constant(null), typeof(Exception))
-                        );
-                    }
+                    var tracebackCall = Ast.Call(
+                        typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.OnTraceEvent)),
+                        _thread,
+                        AstUtils.Constant(locationCookie),
+                        Ast.Convert(Ast.Constant(null), typeof(Exception))
+                    );
 
                     transformedExpression = Ast.Block(
                         Ast.Assign(


### PR DESCRIPTION
This should resolve the issue from https://github.com/IronLanguages/ironpython3/pull/1810 where the first trace event is not getting generated.