### PR TITLE
Enable PopTest on Mono

### DIFF
--- a/tests/Microsoft.Dynamic.Test/InterpreterTest.cs
+++ b/tests/Microsoft.Dynamic.Test/InterpreterTest.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Dynamic.Test {
         }
 
         [Test]
-        [Platform(Exclude="Mono")]
         public void PopTest() {
             // Equal gets converted to an EqualReference instruction which does two pops and a push.
             // If pop doesn't clear the stack one of the two TestGc objects should remain alive.


### PR DESCRIPTION
It seems to be working. Maybe it was not working at some point in time.

Tested on Mono 6.12.0.188, 6.14.1 (macOS), 6.12.0.200 (Ubuntu).