### PR TITLE
Use IronPython from NuGet for HostingTest

### DIFF
--- a/tests/HostingTest/HostingTest.csproj
+++ b/tests/HostingTest/HostingTest.csproj
@@ -10,13 +10,15 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnitLite" Version="3.13.3" />
+
+    <PackageReference Include="DynamicLanguageRuntime" Version="1.3.4" ExcludeAssets="All" />
+    <PackageReference Include="IronPython" Version="3.4.1" />
+    <PackageReference Include="IronPython.StdLib" Version="3.4.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\Microsoft.Dynamic\Microsoft.Dynamic.csproj" />
     <ProjectReference Include="..\..\src\core\Microsoft.Scripting\Microsoft.Scripting.csproj" />
-    <ProjectReference Include="..\..\..\core\IronPython\IronPython.csproj" />
-    <ProjectReference Include="..\..\..\core\IronPython.Modules\IronPython.Modules.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/HostingTest/TestHelpers.cs
+++ b/tests/HostingTest/TestHelpers.cs
@@ -64,7 +64,7 @@ namespace HostingTest {
         public static string BinDirectory { get; private set; }
 
         /// <summary>
-        /// Path to IronPython's standard library, or empty if not found.
+        /// Path to IronPython's standard library, or null if not found.
         /// </summary>
         public static string IronPythonPath { get; private set; }
 
@@ -74,31 +74,9 @@ namespace HostingTest {
             IronPythonPath = GetIronPythonPath();
         }
 
-        /// <summary>
-        /// Finds the root of the IronPython repository by walking up from the assembly location.
-        /// </summary>
-        private static string FindIronPythonRepositoryRoot() {
-            // We start at the current assembly location and look up until we find the "src/core/IronPython.StdLib/lib" directory
-            var current = typeof(HAPITestBase).Assembly.Location;
-            while (!string.IsNullOrEmpty(current)) {
-                var test = Path.Combine(current, "src", "core", "IronPython.StdLib", "lib");
-                if (Directory.Exists(test)) {
-                    return current;
-                }
-                current = Path.GetDirectoryName(current);
-            }
-            return string.Empty;
-        }
-
         private static string GetIronPythonPath() {
-            var root = FindIronPythonRepositoryRoot();
-            if (!string.IsNullOrEmpty(root)) {
-                var path = Path.Combine(root, "src", "core", "IronPython.StdLib", "lib");
-                if (Directory.Exists(path)) {
-                    return path;
-                }
-            }
-            return string.Empty;
+            var path = Path.Combine(Path.GetDirectoryName(typeof(HAPITestBase).Assembly.Location), "lib");
+            return Directory.Exists(path) ? path : null;
         }
 
         private static string GetStandardConfigFile() {


### PR DESCRIPTION
This removes the requirement for the DLR to be a submodule of IronPython to run this test.