### PR TITLE
Move bin directory of the bechmark to the project dir

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -158,7 +158,7 @@ function Purge() {
     Get-ChildItem -Name "obj" -Directory -Path $_BASEDIR -Recurse | Remove-Item -Force -Recurse
 
     Write-Verbose "Deleting ""bin"" directories..."
-    foreach ($dir in @("", "src/samples/sympl/csharp")) {
+    foreach ($dir in @("", "src/samples/sympl/csharp", "tests/Microsoft.Dynamic.Benchmarks")) {
         if (Test-Path (Join-Path $_BASEDIR $dir "bin" -OutVariable targetPath)) {
             Remove-Item -Path $targetPath -Force -Recurse
         }

--- a/tests/Microsoft.Dynamic.Benchmarks/Microsoft.Dynamic.Benchmarks.csproj
+++ b/tests/Microsoft.Dynamic.Benchmarks/Microsoft.Dynamic.Benchmarks.csproj
@@ -7,6 +7,9 @@
     <!-- Add .NET Framework 4.6.2 on Windows -->
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
 
+    <!-- Output to local bin directory to avoid conflicts with other projects -->
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+
     <!-- Benchmarks need optimized builds; Debug config would distort results -->
     <Optimize>true</Optimize>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>


### PR DESCRIPTION
HostingTest depends on IronPython from NuGet, which requires System.Memory 4.5.5 (assembly version 4.0.4.1). When benchmarks and HostingTest shared the same output directory, the newer System.Runtime.CompilerServices.Unsafe (6.1.2 / assembly 6.0.0.0) pulled in by BenchmarkDotNet caused a version conflict.

This PR moved the benchmark's `bin` to the benchmark's directory. On CI, it is still compiled but not executed.