### PR TITLE
Correct order of arguments for Assert.AreEqual in HostingTest

### DIFF
--- a/tests/HostingTest/CompiledCodeTest.cs
+++ b/tests/HostingTest/CompiledCodeTest.cs
@@ -97,9 +97,9 @@ namespace HostingTest {
             compiled.Execute(scope);
 
             object result = scope.GetVariable("x");
-            Assert.AreEqual(result, (object)3);
+            Assert.AreEqual((object)3, result);
             result = scope.GetVariable("w");
-            Assert.AreEqual(result, (object)4);
+            Assert.AreEqual((object)4, result);
 
         }
 
@@ -138,7 +138,7 @@ namespace HostingTest {
             ScriptEngine engine = compiled.Engine;
             object result = scope.GetVariable("x");
             // Verify that engine has the same scope?
-            Assert.AreEqual(engine, _testEng);
+            Assert.AreEqual(_testEng, engine);
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace HostingTest {
             Assert.IsTrue(errorListen._message == null);
             // ScriptScope scope = _PYEng.CreateScope();
             // double result =  compiled.Execute<double>(scope);
-            // Assert.AreEqual(result, (double)2);
+            // Assert.AreEqual((double)2, result);
 
         }
 
@@ -164,10 +164,10 @@ namespace HostingTest {
             object result;
             // This works as spec'd
             result = source.Execute(scope);
-            Assert.AreEqual(result, (object)2);
+            Assert.AreEqual((object)2, result);
 
             result = _PYEng.Execute("2+2", scope);
-            Assert.AreEqual(result, (object)4);
+            Assert.AreEqual((object)4, result);
         }
 
 
@@ -189,7 +189,7 @@ namespace HostingTest {
             Assert.IsTrue(errorListen._message == null);
             ScriptScope scope = _testEng.CreateScope();
             result = compiled.Execute(scope);
-            Assert.AreEqual(result, (object)expectedResult);
+            Assert.AreEqual((object)expectedResult, result);
 
         }
 
@@ -237,7 +237,7 @@ namespace HostingTest {
             for (int i = 0; i < testLoops; i++) {
 
                 result = compiled.Execute(scope);
-                Assert.AreEqual(result, (object)expectedResult);
+                Assert.AreEqual((object)expectedResult, result);
             }
 
         }
@@ -255,7 +255,7 @@ namespace HostingTest {
             CompiledCode compiled = source.Compile(errorListen);
             Assert.IsTrue(errorListen._message == null);
             object result = compiled.Execute();
-            Assert.AreEqual(result, (object)2);
+            Assert.AreEqual((object)2, result);
 
         }
 
@@ -279,7 +279,7 @@ namespace HostingTest {
 
             for (int i = 0; i < testLoops; i++) {
                 result = compiled.Execute();
-                Assert.AreEqual(result, (object)expectedResult);
+                Assert.AreEqual((object)expectedResult, result);
             }
 
         }
@@ -295,7 +295,7 @@ namespace HostingTest {
             compiled.Execute();
             // ScriptScope scope = compiled.DefaultScope();
             // object result = scope.GetVariable("x");
-            // Assert.AreEqual(result, (object)2);
+            // Assert.AreEqual((object)2, result);
 
         }
 

--- a/tests/HostingTest/ObjectOperationsTest.cs
+++ b/tests/HostingTest/ObjectOperationsTest.cs
@@ -191,7 +191,7 @@ namespace HostingTest    {
             string[] result = (string[])_testEng.Operations.GetCallSignatures((object)null);
             
             // Should be empty array of Length zero
-            Assert.AreEqual(result.Length, expectedResult);
+            Assert.AreEqual(expectedResult, result.Length);
         }
 
       
@@ -233,7 +233,7 @@ namespace HostingTest    {
 
             object fooClass = _testEng.Operations.Invoke(objectVar); // create new FooClass
             string[] result = (string[])_testEng.Operations.GetCallSignatures(fooClass);
-            Assert.AreEqual(result.Length, expectedResult.Length);
+            Assert.AreEqual(expectedResult.Length, result.Length);
         }
 
         

--- a/tests/HostingTest/ScriptEngineTest.cs
+++ b/tests/HostingTest/ScriptEngineTest.cs
@@ -23,13 +23,13 @@ namespace HostingTest {
         [Test]
         public void Runtime_Test() {
             //@TODO - Custom language
-            Assert.AreEqual(_runTime.GetEngine("python").Runtime, _runTime);
+            Assert.AreEqual(_runTime, _runTime.GetEngine("python").Runtime);
         }
 
 
         [Test]
         public void LanguageDisplayName_Test() {
-            Assert.AreEqual(_runTime.GetEngine("python").Setup.DisplayName, "IronPython 3.0");
+            Assert.AreEqual("IronPython 3.0", _runTime.GetEngine("python").Setup.DisplayName);
         }
 
 
@@ -58,9 +58,9 @@ namespace HostingTest {
         public void LanguageVersion_Test() {
             //LanguageVersion
             Version ver = _runTime.GetEngine("python").LanguageVersion;
-            Assert.AreEqual(ver, typeof(PythonContext).Assembly.GetName().Version);
+            Assert.AreEqual(typeof(PythonContext).Assembly.GetName().Version, ver);
             //ver = _runTime.GetEngine("ruby").LanguageVersion;
-            //Assert.AreEqual(ver, Ruby.Runtime.RubyContext.IronRubyVersion);
+            //Assert.AreEqual(Ruby.Runtime.RubyContext.IronRubyVersion, ver);
         }
 
         [Test]
@@ -339,7 +339,7 @@ namespace HostingTest {
             scope.SetVariable("x", 1);
             scope.SetVariable("y", 1);
             var result = _PYEng.Execute<int>("x+y", scope);
-            Assert.AreEqual(result, 2);
+            Assert.AreEqual(2, result);
         }
 
         [Test]
@@ -349,7 +349,7 @@ namespace HostingTest {
 
             ScriptScope result = _testEng.ExecuteFile(tmpFile);
             var x = result.GetVariable<int>("x");
-            Assert.AreEqual(x, 4);
+            Assert.AreEqual(4, x);
 
             // resulting scope should be associated with the engine that executed the code:
             Assert.AreEqual(_testEng, result.Engine);
@@ -364,10 +364,10 @@ namespace HostingTest {
             scope.SetVariable("y", 1);
             
             ScriptScope result = _testEng.ExecuteFile(tmpFile, scope);
-            Assert.AreEqual(result, scope);
+            Assert.AreEqual(scope, result);
 
             var x = scope.GetVariable<int>("x");
-            Assert.AreEqual(x, 2);
+            Assert.AreEqual(2, x);
         }
         
         //TODO : these tests should move to script source. 
@@ -639,7 +639,7 @@ def f(arg):
             
             object result = source.Execute(futureScope);
             object r2 = futureScope.GetVariable("r");
-            Assert.AreEqual((double)r2, 0.5);
+            Assert.AreEqual(0.5, (double)r2);
 
         }
 
@@ -661,7 +661,7 @@ def f(arg):
 
             object result = source.Execute(globalScope);
             object r2 = globalScope.GetVariable("r");
-            Assert.AreEqual((double)r2, 0.5);
+            Assert.AreEqual(0.5, (double)r2);
 
         }
         
@@ -750,7 +750,7 @@ def f(arg):
             object excResult = source.Execute(scope);
 
             // A couple of sanity checks
-            //Assert.AreEqual(scope.GetVariable("x"), expResult);
+            //Assert.AreEqual(expResult, scope.GetVariable("x"));
             Assert.IsTrue(File.Exists(tmpFilePath));
 
             // Get the scope associated with the current engine from the existing file script

--- a/tests/HostingTest/ScriptHostTestHelper.cs
+++ b/tests/HostingTest/ScriptHostTestHelper.cs
@@ -111,21 +111,21 @@ namespace HostingTest
        /// ValidateProperties associated with Host -- compare test and expected PAL value(s)
        /// </summary>
        internal void ValidateProperties(PlatformAdaptationLayer testHostPAL, PlatformAdaptationLayer expectedPAL) {
-           Assert.AreEqual(testHostPAL, expectedPAL);
+           Assert.AreEqual(expectedPAL, testHostPAL);
        }
 
        /// <summary>
        /// ValidateProperties associated with Host -- Maybe blocked by bug 462717
        /// </summary>
        internal void ValidateProperties(PlatformAdaptationLayer testHostPAL, string expectedPath) {
-           Assert.AreEqual(testHostPAL.CurrentDirectory, expectedPath);
+           Assert.AreEqual(expectedPath, testHostPAL.CurrentDirectory);
        }
 
        /// <summary>
        /// ValidateProperties associated with Host -- compare test and expected Runtime values
        /// </summary>
        internal void ValidateProperties(ScriptRuntime testHostRuntime, ScriptRuntime expectedRuntime) {
-           Assert.AreEqual(testHostRuntime, expectedRuntime);
+           Assert.AreEqual(expectedRuntime, testHostRuntime);
        }
         /// <summary>
         ///  host.GetSourceFileSearchPath() calls the protected virtual function but - it may
@@ -134,7 +134,7 @@ namespace HostingTest
         /// <param name="testPaths"></param>
         /// <param name="expectedPaths"></param>
        internal void ValidateSourceFileSearchPathValues(IList<string> testPaths, IList<string> expectedPaths) {
-           Assert.AreEqual(testPaths.Count, expectedPaths.Count);
+           Assert.AreEqual(expectedPaths.Count, testPaths.Count);
            Assert.IsTrue(testPaths.Count > 0);
            Assert.IsTrue(expectedPaths.Contains(testPaths[0]));
        }

--- a/tests/HostingTest/ScriptIOTestHelper.cs
+++ b/tests/HostingTest/ScriptIOTestHelper.cs
@@ -48,7 +48,7 @@ namespace HostingTest
 
            string[] lines = File.ReadAllLines(fname);
            int n = lines.Length;
-           Assert.AreEqual(lines[n - 1], expectedOutput);
+           Assert.AreEqual(expectedOutput, lines[n - 1]);
 
        }
     

--- a/tests/HostingTest/ScriptRuntimeTest.cs
+++ b/tests/HostingTest/ScriptRuntimeTest.cs
@@ -345,7 +345,7 @@ namespace HostingTest{
             dict[key] = editDict;
             attachedScope.SetVariable(key, editScope);
 
-            Assert.AreEqual(dict[key], editScope);
+            Assert.AreEqual(editScope, dict[key]);
 
             dict[key] = editDict;
             Assert.AreEqual(editDict, attachedScope.GetVariable(key));
@@ -582,7 +582,7 @@ namespace HostingTest{
             var setup = new ScriptRuntimeSetup();
             setup.LanguageSetups.Add(new("IronPython.Runtime.PythonContext,IronPython", "IronPython", ["py"], ["py"]));
             var python = new ScriptRuntime(setup).GetEngine("py");
-            Assert.AreEqual(python.Setup.DisplayName, "IronPython");
+            Assert.AreEqual("IronPython", python.Setup.DisplayName);
         }
 
         [Test]

--- a/tests/HostingTest/ScriptScopeTest.cs
+++ b/tests/HostingTest/ScriptScopeTest.cs
@@ -207,8 +207,8 @@ namespace HostingTest {
             int expectedResult = 2;
 
             // Verify value and type are as expected
-            Assert.AreEqual(testResult0, expectedResult);
-            Assert.AreEqual(testResult1, expectedResult);
+            Assert.AreEqual(expectedResult, testResult0);
+            Assert.AreEqual(expectedResult, testResult1);
         }
 
         /// <summary>
@@ -637,7 +637,7 @@ namespace HostingTest {
         [Test]
         public void Execute_ValidExpressionResult()
         {
-            Assert.AreEqual((int)(_testEng.Execute("1 + 1")), 2);
+            Assert.AreEqual(2, (int)(_testEng.Execute("1 + 1")));
         }
        
         // Bug # 482429 validation
@@ -645,7 +645,7 @@ namespace HostingTest {
         [Test]
         public void ExecuteGeneric_ValidExpressionResult()
         {
-            Assert.AreEqual((int)(_testEng.Execute<int>("1 + 1")), 2);
+            Assert.AreEqual(2, (int)(_testEng.Execute<int>("1 + 1")));
         }
 
         // Bug # 485727
@@ -656,7 +656,7 @@ namespace HostingTest {
             scope.SetVariable("var1", 1);
             int expected1;
             Assert.IsTrue(scope.TryGetVariable<int>("var1", out expected1));
-            Assert.AreEqual(expected1, 1);
+            Assert.AreEqual(1, expected1);
             
         }
 
@@ -667,7 +667,7 @@ namespace HostingTest {
             ScriptScope scope = _runtime.CreateScope();
             string expected1;
             Assert.IsFalse(scope.TryGetVariable<string>("var1", out expected1));
-            Assert.AreEqual(expected1, null);
+            Assert.AreEqual(null, expected1);
             
         }
 
@@ -765,7 +765,7 @@ namespace HostingTest {
             ObjectHandle obj = scope.GetVariableHandle("two");
 
             int two = (int)obj.Unwrap();
-            Assert.AreEqual(two, 2);
+            Assert.AreEqual(2, two);
 
         }
 

--- a/tests/HostingTest/ScriptSourceTest.cs
+++ b/tests/HostingTest/ScriptSourceTest.cs
@@ -105,7 +105,7 @@ namespace HostingTest {
             // This should the line of code input during CreateScriptSourceFromString
             int actualCode = 1;
             string codeLine = sSrc.GetCodeLine(actualCode);
-            Assert.AreEqual(codeLine, _codeSnippets[CodeType.OneLineAssignmentStatement]);
+            Assert.AreEqual(_codeSnippets[CodeType.OneLineAssignmentStatement], codeLine);
         }
         
         /// <summary>
@@ -126,7 +126,7 @@ namespace HostingTest {
             // Get the second line 
             string codeLine = sSrc.GetCodeLine(expectedCodeLine);
             // Check the expected value
-            Assert.AreEqual(codeLine, strExpectedTestLine);
+            Assert.AreEqual(strExpectedTestLine, codeLine);
         }
 
         [Test]
@@ -245,7 +245,7 @@ namespace HostingTest {
         {
             string srcPath = TestHelpers.CreateTempSourceFile(_codeSnippets[CodeType.ValidMultiLineMixedType], ".py");
             ScriptSource source = _testEng.CreateScriptSourceFromFile(srcPath);
-            Assert.AreEqual(source.Path, srcPath, "'The Path is null if not set explicitly on construction.'");
+            Assert.AreEqual(srcPath, source.Path, "'The Path is null if not set explicitly on construction.'");
         }
 
         [Test]
@@ -494,7 +494,7 @@ namespace HostingTest {
             source.Execute(scope);
 
             Func<string> sayHello = scope.GetVariable<Func<string>>("bar");
-            Assert.AreEqual(sayHello(), "Hello World");
+            Assert.AreEqual("Hello World", sayHello());
         }
 
         /// <summary>
@@ -524,7 +524,7 @@ namespace HostingTest {
 
             // Now call fooTest's object member function 'f'
             string result = sayHello();
-            Assert.AreEqual(result, expResult);
+            Assert.AreEqual(expResult, result);
             
         }
         /// <summary>
@@ -553,7 +553,7 @@ namespace HostingTest {
             Func<object, string> sayHello = _testEng.Operations.GetMember<Func<object, string>>(FooClass, "f");
             string result = sayHello(fooTest);
 
-            Assert.AreEqual(result, expResult);
+            Assert.AreEqual(expResult, result);
         }
 
         /// <summary>
@@ -612,7 +612,7 @@ test1 = abs(test1)";
             
             // Check affect of Execution
             object testResult = scope.GetVariable("test1");
-            Assert.AreEqual(testResult, 10);
+            Assert.AreEqual(10, testResult);
         }
 
 
@@ -677,7 +677,7 @@ test1 = abs(test1)";
 
             // Create second unit reader
             SourceCodeReader srcSecondUnitReader = source.GetReader();
-            Assert.AreEqual(srcSecondUnitReader.ReadLine(), expValue);
+            Assert.AreEqual(expValue, srcSecondUnitReader.ReadLine());
 
         }
 
@@ -718,7 +718,7 @@ test1 = abs(test1)";
                 cnt++;
             }
 
-            Assert.AreEqual(cnt, testInput.Length);
+            Assert.AreEqual(testInput.Length, cnt);
             Assert.AreEqual(testInput, strBuffer.ToString());
         }
 

--- a/tests/HostingTest/ScriptSourceTestHelper.cs
+++ b/tests/HostingTest/ScriptSourceTestHelper.cs
@@ -92,12 +92,12 @@ namespace HostingTest {
         internal void ValidateKind(string InputCode, SourceCodeKind input, SourceCodeKind ExpectedValue) {
             ScriptSource ss = CreateScriptSource(InputCode, input);
             
-            Assert.AreEqual(ss.Kind, ExpectedValue);
+            Assert.AreEqual(ExpectedValue, ss.Kind);
         }
 
         internal void ValidateKindAsFile(string InputCode) {
             ScriptSource ss = CreateFileBasedScriptSource(InputCode);
-            Assert.AreEqual(ss.Kind, SourceCodeKind.File);
+            Assert.AreEqual(SourceCodeKind.File, ss.Kind);
         }
 
         internal void ValidateGetCodeProperties(string InputCode, ScriptCodeParseResult ExpectedValue) {

--- a/tests/HostingTest/TestHelpers.cs
+++ b/tests/HostingTest/TestHelpers.cs
@@ -140,9 +140,9 @@ namespace HostingTest {
         }
         
         internal static void AreEqualArrays<T>(IList<T> expected, IList<T> actual) {
-            Assert.AreEqual(actual.Count, expected.Count);
+            Assert.AreEqual(expected.Count, actual.Count);
             for (int i = 0; i < actual.Count; i++) {
-                Assert.AreEqual(actual[i], expected[i]);
+                Assert.AreEqual(expected[i], actual[i]);
             }
         }
 


### PR DESCRIPTION
For some reason most arguments to `Assert.AreEqual` were reversed. Only cases in `ScriptRuntimeSetupTest.cs` were in order. This did not have any effect on the result of the assert — equality is symmetric — but if it fails, the error mesages were wrong.

This PR fixes it, in HostingTest.