### PR TITLE
Simplify CollectionExtensions in Microsoft.Scripting

### DIFF
--- a/src/core/Microsoft.Dynamic/Interpreter/LightCompiler.cs
+++ b/src/core/Microsoft.Dynamic/Interpreter/LightCompiler.cs
@@ -1162,7 +1162,7 @@ namespace Microsoft.Scripting.Interpreter {
             // force compilation for now for ref types
             // also could be a mutable value type, Delegate.CreateDelegate and MethodInfo.Invoke both can't handle this, we
             // need to generate code.
-            if (!CollectionUtils.TrueForAll(parameters, (p) => !p.ParameterType.IsByRef) ||
+            if (!parameters.All(static p => !p.ParameterType.IsByRef) ||
                 (!node.Method.IsStatic && node.Method.DeclaringType.IsValueType && !node.Method.DeclaringType.IsPrimitive)) {
                 _forceCompile = true;
             }
@@ -1207,7 +1207,7 @@ namespace Microsoft.Scripting.Interpreter {
 
             if (node.Constructor is not null) {
                 var parameters = node.Constructor.GetParameters();
-                if (!CollectionUtils.TrueForAll(parameters, (p) => !p.ParameterType.IsByRef)
+                if (!parameters.All(static p => !p.ParameterType.IsByRef)
 #if FEATURE_LCG
                      || node.Constructor.DeclaringType == typeof(DynamicMethod)
 #endif

--- a/src/core/Microsoft.Scripting/Hosting/Configuration/Section.cs
+++ b/src/core/Microsoft.Scripting/Hosting/Configuration/Section.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using System.Linq;
 using System.Xml;
 
 using Microsoft.Scripting.Runtime;

--- a/src/core/Microsoft.Scripting/Hosting/ScriptRuntime.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ScriptRuntime.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
+using System.Linq;
 using System.IO;
 using System.Reflection;
 
@@ -280,7 +281,7 @@ namespace Microsoft.Scripting.Hosting {
             }
 
             // Didn't find the file, throw
-            string allPaths = searchPaths.Aggregate((x, y) => x + ", " + y);
+            string allPaths = searchPaths.Aggregate(static (x, y) => x + ", " + y);
             throw new FileNotFoundException($"File '{path}' not found in language's search path: {allPaths}");
         }
 

--- a/src/core/Microsoft.Scripting/Runtime/DlrConfiguration.cs
+++ b/src/core/Microsoft.Scripting/Runtime/DlrConfiguration.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 
@@ -134,12 +135,12 @@ namespace Microsoft.Scripting.Runtime {
             IDictionary<string, object> options, string paramName) {
             ContractUtils.Requires(!_frozen, "Configuration cannot be modified once the runtime is initialized");
             ContractUtils.Requires(
-                names.TrueForAll((id) => !String.IsNullOrEmpty(id) && !_languageNames.ContainsKey(id)),
+                names.All(id => !String.IsNullOrEmpty(id) && !_languageNames.ContainsKey(id)),
                 paramName ?? "names",
                 "Language name should not be null, empty or duplicated between languages"
             );
             ContractUtils.Requires(
-                fileExtensions.TrueForAll((ext) => !String.IsNullOrEmpty(ext) && !_languageExtensions.ContainsKey(ext)),
+                fileExtensions.All(ext => !String.IsNullOrEmpty(ext) && !_languageExtensions.ContainsKey(ext)),
                 paramName ?? "fileExtensions",
                 "File extension should not be null, empty or duplicated between languages"
             );

--- a/src/core/Microsoft.Scripting/Runtime/LanguageContext.cs
+++ b/src/core/Microsoft.Scripting/Runtime/LanguageContext.cs
@@ -466,7 +466,7 @@ namespace Microsoft.Scripting.Runtime {
             }
 
             public override DynamicMetaObject FallbackInvokeMember(DynamicMetaObject target, DynamicMetaObject[] args, DynamicMetaObject errorSuggestion) {
-                return ErrorMetaObject(ReturnType, target, args.AddFirst(target), errorSuggestion);
+                return ErrorMetaObject(ReturnType, target, [target, ..args], errorSuggestion);
             }
 
             private static Expression[] GetArgs(DynamicMetaObject target, DynamicMetaObject[] args) {
@@ -543,17 +543,17 @@ namespace Microsoft.Scripting.Runtime {
         public virtual IList<string> GetMemberNames(object obj) {
             if (obj is IDynamicMetaObjectProvider ido) {
                 var mo = ido.GetMetaObject(Expression.Parameter(typeof(object), null));
-                return mo.GetDynamicMemberNames().ToReadOnly();
+                return mo.GetDynamicMemberNames().ToReadOnlyCollection();
             }
-            return EmptyArray<string>.Instance;
+            return Array.Empty<string>();
         }
 
         public virtual string GetDocumentation(object obj) {
-            return String.Empty;
+            return string.Empty;
         }
 
         public virtual IList<string> GetCallSignatures(object obj) {
-            return EmptyArray<string>.Instance;
+            return Array.Empty<string>();
         }
 
         public virtual bool IsCallable(object obj) => obj is Delegate;

--- a/src/core/Microsoft.Scripting/Utils/ArrayUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ArrayUtils.cs
@@ -9,9 +9,9 @@ using System.Text;
 
 namespace Microsoft.Scripting.Utils {
     internal static class ArrayUtils {
-        public static readonly string[] EmptyStrings = EmptyArray<string>.Instance;
+        public static readonly string[] EmptyStrings = Array.Empty<string>();
 
-        public static readonly object[] EmptyObjects = EmptyArray<object>.Instance;
+        public static readonly object[] EmptyObjects = Array.Empty<object>();
 
         internal sealed class FunctorComparer<T> : IComparer<T> {
             private readonly Comparison<T> _comparison;
@@ -60,7 +60,7 @@ namespace Microsoft.Scripting.Utils {
 
         public static T[] MakeArray<T>(ICollection<T> list) {
             if (list.Count == 0) {
-                return EmptyArray<T>.Instance;
+                return [];
             }
 
             T[] res = new T[list.Count];

--- a/src/core/Microsoft.Scripting/Utils/CollectionExtensions.cs
+++ b/src/core/Microsoft.Scripting/Utils/CollectionExtensions.cs
@@ -5,18 +5,18 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 
 namespace Microsoft.Scripting.Utils {
     internal static class CollectionExtensions {
         /// <summary>
-        /// Wraps the provided enumerable into a ReadOnlyCollection{T}
-        /// 
-        /// Copies all of the data into a new array, so the data can't be
-        /// changed after creation. The exception is if the enumerable is
-        /// already a ReadOnlyCollection{T}, in which case we just return it.
+        /// Materlializes the provided enumerable if needed and wraps it in a ReadOnlyCollection{T}
         /// </summary>
-        internal static ReadOnlyCollection<T> ToReadOnly<T>(this IEnumerable<T> enumerable) {
+        /// <remarks>
+        /// Copies all of the data into a new array, so the data can't be
+        /// accidentally changed after creation. The exception is if the enumerable is
+        /// already a ReadOnlyCollection{T}, in which case we just return it.
+        /// </remarks>
+        internal static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> enumerable) {
             if (enumerable is null) {
                 return EmptyReadOnlyCollection<T>.Instance;
             }
@@ -37,61 +37,11 @@ namespace Microsoft.Scripting.Utils {
             }
 
             // ToArray trims the excess space and speeds up access
-            return new ReadOnlyCollection<T>(new List<T>(enumerable).ToArray());
-        }
-        internal static T[] ToArray<T>(this IEnumerable<T> enumerable) {
-            if (enumerable is ICollection<T> c) {
-                var result = new T[c.Count];
-                c.CopyTo(result, 0);
-                return result;
-            }
-            return new List<T>(enumerable).ToArray();
-        }
-
-        
-        internal static bool Any<T>(this IEnumerable<T> source, Func<T, bool> predicate) {
-            foreach (T element in source) {
-                if (predicate(element)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        internal static TSource Aggregate<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, TSource> func) {
-            using (IEnumerator<TSource> e = source.GetEnumerator()) {
-                if (!e.MoveNext()) throw new ArgumentException("Collection is empty", nameof(source));
-                TSource result = e.Current;
-                while (e.MoveNext()) result = func(result, e.Current);
-                return result;
-            }
-        }
-
-        internal static T[] AddFirst<T>(this IList<T> list, T item) {
-            T[] res = new T[list.Count + 1];
-            res[0] = item;
-            list.CopyTo(res, 1);
-            return res;
-        }
-
-        internal static bool TrueForAll<T>(this IEnumerable<T> collection, Predicate<T> predicate) {
-            ContractUtils.RequiresNotNull(collection, nameof(collection));
-            ContractUtils.RequiresNotNull(predicate, nameof(predicate));
-
-            foreach (T item in collection) {
-                if (!predicate(item)) return false;
-            }
-
-            return true;
+            return new ReadOnlyCollection<T>(System.Linq.Enumerable.ToArray(enumerable));
         }
     }
-
 
     internal static class EmptyReadOnlyCollection<T> {
         internal static readonly ReadOnlyCollection<T> Instance = new(Array.Empty<T>());
-    }
-
-    internal static class EmptyArray<T> {
-        internal static readonly T[] Instance = Array.Empty<T>();
     }
 }


### PR DESCRIPTION
Many became redundant in .NET. The .NET implementations are as good as the ones from `Microsoft.Scripting.dll`, sometimes more optimized, sometimes avoid unnecessary allocations on heap.

The class is internal so no harm done. There is another class `CollectionExtensions` in `Microsoft.Dynamic` that needs to be reviewed too; it is in namespace `Microsoft.Scripting` (?) but sometimes contains simply a copy of functionality from `Microsoft.Scripting.dll`.