### PR TITLE
Refactor ToReadOnlyCollection in Microsoft.Scripting

### DIFF
--- a/src/core/Microsoft.Scripting/LanguageOptions.cs
+++ b/src/core/Microsoft.Scripting/LanguageOptions.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Scripting {
             _perfStats = GetOption(options, "PerfStats", false);
             _noAdaptiveCompilation = GetOption(options, "NoAdaptiveCompilation", false);
             _compilationThreshold = GetOption(options, "CompilationThreshold", -1);
-            _searchPaths = GetSearchPathsOption(options) ?? EmptyReadOnlyCollection<string>.Instance;
+            _searchPaths = GetSearchPathsOption(options) ?? ReadOnlyCollection<string>.Empty;
         }
 
         public static T GetOption<T>(IDictionary<string, object> options, string name, T defaultValue) {
@@ -128,6 +128,6 @@ namespace Microsoft.Scripting {
             return GetStringCollectionOption(options, "SearchPaths", Path.PathSeparator);
         }
 
-        protected static readonly ReadOnlyCollection<string> EmptyStringCollection = new(ArrayUtils.EmptyStrings);
+        protected static readonly ReadOnlyCollection<string> EmptyStringCollection = ReadOnlyCollection<string>.Empty;
     }
 }

--- a/src/core/Microsoft.Scripting/Utils/CollectionExtensions.cs
+++ b/src/core/Microsoft.Scripting/Utils/CollectionExtensions.cs
@@ -5,8 +5,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Scripting.Utils {
+
+    /// <seealso href="https://github.com/dotnet/runtime/blob/main/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs"/>
     internal static class CollectionExtensions {
         /// <summary>
         /// Materlializes the provided enumerable if needed and wraps it in a ReadOnlyCollection{T}
@@ -14,34 +18,33 @@ namespace Microsoft.Scripting.Utils {
         /// <remarks>
         /// Copies all of the data into a new array, so the data can't be
         /// accidentally changed after creation. The exception is if the enumerable is
-        /// already a ReadOnlyCollection{T}, in which case we just return it.
+        /// already a ReadOnlyCollection{T} (or its subclass), in which case we just return it.
         /// </remarks>
+        /// <seealso href="https://github.com/dotnet/runtime/blob/b70c35ed8a2e7ae0d91de76f4f5d26c2e7d2c6cd/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs#L58"/>
         internal static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> enumerable) {
-            if (enumerable is null) {
-                return EmptyReadOnlyCollection<T>.Instance;
-            }
-
-            if (enumerable is ReadOnlyCollection<T> roCollection) {
-                return roCollection;
-            }
-
-            if (enumerable is ICollection<T> collection) {
-                int count = collection.Count;
-                if (count == 0) {
-                    return EmptyReadOnlyCollection<T>.Instance;
-                }
-
-                T[] array = new T[count];
-                collection.CopyTo(array, 0);
-                return new ReadOnlyCollection<T>(array);
-            }
-
-            // ToArray trims the excess space and speeds up access
-            return new ReadOnlyCollection<T>(System.Linq.Enumerable.ToArray(enumerable));
+            return enumerable switch {
+                null => ReadOnlyCollection<T>.Empty,
+                ReadOnlyCollection<T> roc => roc,
+                ReadOnlyCollectionBuilder<T> builder => builder.ToReadOnlyCollection(),
+                _ => enumerable.ToArray() switch {  // ToArray does all necessary casting, copying, and possible optimizations
+                    { Length: 0 } => ReadOnlyCollection<T>.Empty,
+                    var array => new ReadOnlyCollection<T>(array),
+                },
+            };
         }
-    }
 
-    internal static class EmptyReadOnlyCollection<T> {
-        internal static readonly ReadOnlyCollection<T> Instance = new(Array.Empty<T>());
+
+#if !NET8_0_OR_GREATER
+        // Emulates ReadOnlyCollection<T>.Empty form .NET 8.0+ with what is available in .NET Framework et al.
+        extension<T>(ReadOnlyCollection<T>) {
+            internal static ReadOnlyCollection<T> Empty => EmptyReadOnlyCollection<T>.Instance;
+        }
+
+        // CS9282: Extension declarations can include only methods or properties
+        // so a readonly field must be in a separate static class.
+        private static class EmptyReadOnlyCollection<T> {
+            internal static readonly ReadOnlyCollection<T> Instance = new(Array.Empty<T>());
+        }
+#endif
     }
 }


### PR DESCRIPTION
Follow-up on #339. In the end I did not manage to eliminate `CollectionExtensions` from `Microsoft.Scripting`. There is only one place that uses it, but it receives `IEnumerable` from the .NET runtime, which, in turn, may receive it from the user code, so there is no way of knowing what will be processed. The existing code is not simple. To avoid repeating myself in `Microsoft.Dynamic` I am now really tempted to make it public, since it may be useful to a wider range of (user) code. In `Microsoft.Dynamic` it is being used in a handful of places. It is even being defined (again) in .NET, in `System.Dynamic.Utils`, but not public.

Another options are: make `Microsoft.Dynamic` a friend of `Microsoft.Scripting`, or use `UnsafeAssessorAttribute` (.NET only). I do not consider reflection; I'd rather break DRY.