### PR TITLE
Upgrade test framework to NUnit 4.5

### DIFF
--- a/tests/HostingTest/HostingTest.csproj
+++ b/tests/HostingTest/HostingTest.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnitLite" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
     <PackageReference Include="DynamicLanguageRuntime" Version="1.3.5" ExcludeAssets="All" />
     <PackageReference Include="IronPython" Version="3.4.2" />

--- a/tests/HostingTest/ScriptEngineTest.cs
+++ b/tests/HostingTest/ScriptEngineTest.cs
@@ -72,7 +72,7 @@ namespace HostingTest {
 
                 //Exec the code in a new scope
                 ScriptScope scope = _runTime.CreateScope();
-                Assert.AreEqual(null, src.Execute(scope));
+                Assert.That(src.Execute(scope), Is.Null);
                 Assert.AreEqual(_codeSnippets[CodeType.Valid1], src.GetCode());
 
                 //Verify the scope's contents after execution
@@ -760,7 +760,7 @@ def f(arg):
             Assert.IsNotNull(fileScope);
 
             // If we get a valid scope check the expected contents. 
-            Assert.AreEqual(expResult, fileScope.GetVariable("x"));
+            Assert.That(fileScope.GetVariable("x"), Is.EqualTo(expResult));
         }
 
         /// <summary>

--- a/tests/HostingTest/ScriptRuntimeSetupTest.cs
+++ b/tests/HostingTest/ScriptRuntimeSetupTest.cs
@@ -214,7 +214,7 @@ namespace HostingTest {
             var srs = ScriptRuntimeSetup.ReadConfiguration(configFile);
             var runtime = new ScriptRuntime(srs);
 
-            Assert.AreEqual(5, runtime.GetEngine("py").Execute("2+3"));
+            Assert.That(runtime.GetEngine("py").Execute("2+3"), Is.EqualTo(5));
         }
 
         [Test]
@@ -234,7 +234,7 @@ namespace HostingTest {
             var eng = sr.GetEngine("py");
             var eng2 = sr.GetEngine("rb");
 
-            Assert.AreEqual(5, eng.Execute("2+3"));
+            Assert.That(eng.Execute("2+3"), Is.EqualTo(5));
         }
 
         [Test]

--- a/tests/HostingTest/ScriptRuntimeTest.cs
+++ b/tests/HostingTest/ScriptRuntimeTest.cs
@@ -276,12 +276,12 @@ namespace HostingTest{
             dict[key] = 1;
             
             _runtime.Globals = _testEng.CreateScope(new ObjectDictionaryExpando(dict));
-            Assert.AreEqual(1, _runtime.Globals.GetVariable( key));
+            Assert.That(_runtime.Globals.GetVariable(key), Is.EqualTo(1));
 
             dict[key] = 2;
             _runtime.Globals = _testEng.CreateScope(new ObjectDictionaryExpando(dict));
 
-            Assert.AreEqual(2, _runtime.Globals.GetVariable(key));
+            Assert.That(_runtime.Globals.GetVariable(key), Is.EqualTo(2));
         }
 
         [Test]
@@ -348,7 +348,7 @@ namespace HostingTest{
             Assert.AreEqual(editScope, dict[key]);
 
             dict[key] = editDict;
-            Assert.AreEqual(editDict, attachedScope.GetVariable(key));
+            Assert.That(attachedScope.GetVariable(key), Is.EqualTo(editDict));
         }
 
         [Test]

--- a/tests/HostingTest/ScriptScopeTest.cs
+++ b/tests/HostingTest/ScriptScopeTest.cs
@@ -71,7 +71,7 @@ namespace HostingTest {
             KeyValuePair<string, object> testVar = new KeyValuePair<string, object>(string.Empty, 1);
             scope.SetVariable(testVar.Key, testVar.Value);
 
-            Assert.AreEqual(testVar.Value, scope.GetVariable(testVar.Key));
+            Assert.That(scope.GetVariable(testVar.Key), Is.EqualTo(testVar.Value));
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace HostingTest {
             var testVar = new KeyValuePair<string, object>("one", 1);
             scope.SetVariable(testVar.Key, testVar.Value);
 
-            Assert.AreEqual(testVar.Value, scope.GetVariable(testVar.Key));
+            Assert.That(scope.GetVariable(testVar.Key), Is.EqualTo(testVar.Value));
         }
 
 
@@ -122,7 +122,7 @@ namespace HostingTest {
             var testPair = new KeyValuePair<string, object>("", 1);
             scope.SetVariable(testPair.Key, testPair.Value);
 
-            Assert.AreEqual(testPair.Value, scope.GetVariable(testPair.Key));
+            Assert.That(scope.GetVariable(testPair.Key), Is.EqualTo(testPair.Value));
         }
 
         /// <summary>
@@ -137,13 +137,13 @@ namespace HostingTest {
             var testPair = new KeyValuePair<string, object>("SomeVar", 1);
             scope.SetVariable(testPair.Key, testPair.Value);
 
-            Assert.AreEqual(testPair.Value, scope.GetVariable(testPair.Key));
+            Assert.That(scope.GetVariable(testPair.Key), Is.EqualTo(testPair.Value));
 
             var newCaseVar = new KeyValuePair<string, object>("someVar", "abc");
             scope.SetVariable(newCaseVar.Key, newCaseVar.Value);
 
-            Assert.AreEqual(newCaseVar.Value, scope.GetVariable(newCaseVar.Key));
-            Assert.AreEqual(testPair.Value, scope.GetVariable(testPair.Key));
+            Assert.That(scope.GetVariable(newCaseVar.Key), Is.EqualTo(newCaseVar.Value));
+            Assert.That(scope.GetVariable(testPair.Key), Is.EqualTo(testPair.Value));
         }
 
         /// <summary>
@@ -157,13 +157,13 @@ namespace HostingTest {
             var testVar = new KeyValuePair<string, object>("SomeVar", 1);
             scope.SetVariable(testVar.Key, testVar.Value);
 
-            Assert.AreEqual(testVar.Value, scope.GetVariable(testVar.Key));
+            Assert.That(scope.GetVariable(testVar.Key), Is.EqualTo(testVar.Value));
 
             // New value
             var expectedVar = new KeyValuePair<string, object>("SomeVar", 2);
             scope.SetVariable(expectedVar.Key, expectedVar.Value);
 
-            Assert.AreEqual(expectedVar.Value, scope.GetVariable(expectedVar.Key));
+            Assert.That(scope.GetVariable(expectedVar.Key), Is.EqualTo(expectedVar.Value));
             Assert.AreEqual(1, scope.GetVariableCount());
         }
 
@@ -179,10 +179,10 @@ namespace HostingTest {
             var testVar = new KeyValuePair<string, object>("var1", 1);
             scope.SetVariable(testVar.Key, testVar.Value);
 
-            Assert.AreEqual(testVar.Value, scope.GetVariable(testVar.Key));
+            Assert.That(scope.GetVariable(testVar.Key), Is.EqualTo(testVar.Value));
 
             scope.SetVariable(testVar.Key, "HelloWorld");
-            Assert.AreEqual("HelloWorld", scope.GetVariable(testVar.Key));
+            Assert.That(scope.GetVariable(testVar.Key), Is.EqualTo("HelloWorld"));
         }
 
         [Test]
@@ -794,13 +794,13 @@ namespace HostingTest {
             // Greate a new Scope and or get default scope...
             ScriptScope testScope = _testEng.Runtime.CreateScope(new ObjectDictionaryExpando(global));
             foreach (string str in testScope.GetVariableNames()) {
-                Assert.AreEqual(global[str], testScope.GetVariable(str));
+                Assert.That(testScope.GetVariable(str), Is.EqualTo(global[str]));
             }
 
             // Now verify that changes to the TestScope are reflected in the global scope.
             string updateTestKey = "Four";
             testScope.SetVariable(updateTestKey, 4);
-            Assert.AreEqual(global[updateTestKey], testScope.GetVariable(updateTestKey));
+            Assert.That(testScope.GetVariable(updateTestKey), Is.EqualTo(global[updateTestKey]));
 
         }
 

--- a/tests/HostingTest/TestHelpers.cs
+++ b/tests/HostingTest/TestHelpers.cs
@@ -16,7 +16,7 @@ using System.Diagnostics;
 namespace HostingTest {
     using Assert = NUnit.Framework.Assert;
 
-    internal class TestHelpers {
+    internal static class TestHelpers {
 
         /// <summary>
         /// A stream that wraps a TextWriter, converting byte writes to text.

--- a/tests/Metadata/Metadata.csproj
+++ b/tests/Metadata/Metadata.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnitLite" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Microsoft.Dynamic.Test/Microsoft.Dynamic.Test.csproj
+++ b/tests/Microsoft.Dynamic.Test/Microsoft.Dynamic.Test.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnitLite" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Scripting.Test/Microsoft.Scripting.Test.csproj
+++ b/tests/Microsoft.Scripting.Test/Microsoft.Scripting.Test.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnitLite" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For all four tests in the DLR. NUnit 4 has better support for async methods; this may become handy.

Some `HostingTest` assertions have been changed from the classic `Assert.AreEqual` to the new constraint-based `Assert.That` because, although `Assert.AreEqual` is available, it is an extension method now, and extension methods do not work well with `dynamic` arguments. Perhaps it would be neat to change all assertions to the modern form.