### PR TITLE
Add TFM net9.0

### DIFF
--- a/src/core/Microsoft.Dynamic/Microsoft.Dynamic.csproj
+++ b/src/core/Microsoft.Dynamic/Microsoft.Dynamic.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>Microsoft.Scripting</RootNamespace>
     <BaseAddress>859832320</BaseAddress>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <!-- Suppress CA2263 for .NET 10 - prefer to keep consistent code across all frameworks -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0' ">
+    <!-- Suppress CA2263 for .NET 9+ - prefer to keep consistent code across all frameworks -->
     <NoWarn>$(NoWarn);CA2263</NoWarn>
   </PropertyGroup>
 

--- a/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
+++ b/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <BaseAddress>857735168</BaseAddress>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -23,6 +23,13 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="System.CodeDom" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">


### PR DESCRIPTION
Having target `net9.0` allows for better testing of features available from .NET 9.0 onwards.