### PR TITLE
Run HostingTest on all frameworks

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -93,9 +93,6 @@ function Test([String] $target, [String] $configuration, [String[]] $frameworks,
         if ($null -eq $frameworkSettings) { $frameworkSettings = $_defaultFrameworkSettings }
 
         foreach ($testdesc in $frameworkSettings["tests"].Keys) {
-            if ($testdesc -eq "HostingTest" -and ($framework -ne "net462" -or -not $IsWindows)) {
-                continue
-            }
 
             $testname = "";
             $filtername = $target

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!-- Import per-TFM feature flags (e.g. FEATURE_REMOTING for net462) -->
+  <Import Project="$(DlrBuildDir)\$(TargetFramework).props" Condition="'$(TargetFramework)' != ''" />
+
+  <PropertyGroup>
+    <DefineConstants>$(Features);$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+</Project>

--- a/tests/HostingTest/HAPITestBase.cs
+++ b/tests/HostingTest/HAPITestBase.cs
@@ -19,7 +19,10 @@ namespace HostingTest {
         //Don't use this member. Use _runtime instead. 
         //This will be deleted once all the files are switched over to the id with correct casing
         protected ScriptRuntime _runTime;
-        protected ScriptRuntime _runtime, _remoteRuntime;
+        protected ScriptRuntime _runtime;
+#if FEATURE_REMOTING
+        protected ScriptRuntime _remoteRuntime;
+#endif
 
         protected ScriptEngine _testEng;
 
@@ -33,7 +36,9 @@ namespace HostingTest {
             var ses = CreateSetup();
             ses.HostType = typeof(TestHost);
             _runtime = new ScriptRuntime(ses);
+#if FEATURE_REMOTING
             _remoteRuntime = ScriptRuntime.CreateRemote(TestHelpers.CreateAppDomain("Alternate"), ses);
+#endif
 
             _runTime = _runtime;// _remoteRuntime;
 
@@ -68,9 +73,11 @@ namespace HostingTest {
             return new ScriptRuntime(CreateSetup());
         }
 
+#if FEATURE_REMOTING
         public static ScriptRuntime CreateRemoteRuntime(AppDomain domain) {
             return ScriptRuntime.CreateRemote(domain, CreateSetup());
         }
+#endif
 
         public static ScriptRuntimeSetup CreateSetup() {
             var configFile = TestHelpers.StandardConfigFile;

--- a/tests/HostingTest/HostingTest.csproj
+++ b/tests/HostingTest/HostingTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0;net10.0</TargetFrameworks>
     <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
   </PropertyGroup>
 
@@ -19,6 +19,18 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\Microsoft.Dynamic\Microsoft.Dynamic.csproj" />
     <ProjectReference Include="..\..\src\core\Microsoft.Scripting\Microsoft.Scripting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/HostingTest/ObjectOperationsTest.cs
+++ b/tests/HostingTest/ObjectOperationsTest.cs
@@ -35,12 +35,14 @@ namespace HostingTest    {
             _testEng.Operations.IsCallable((object)null);
         }
 
+#if FEATURE_REMOTING
         [Test]
         [Negative]
         [ExpectedException(typeof(ArgumentNullException))]
         public void IsCallable_NullObjectHandleArgument() {
             _testEng.Operations.IsCallable((ObjectHandle)null);
         }
+#endif
 
 
         /// <summary>

--- a/tests/HostingTest/ScriptEngineTest.cs
+++ b/tests/HostingTest/ScriptEngineTest.cs
@@ -297,6 +297,7 @@ namespace HostingTest {
             _testEng.Execute<object>("", null);
         }
 
+#if FEATURE_REMOTING
         [Negative]
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
@@ -310,6 +311,7 @@ namespace HostingTest {
         public void ExecuteAndWrap_WithNullScope() {
             _testEng.ExecuteAndWrap("", null);
         }
+#endif
 
         [Negative]
         [Test]

--- a/tests/HostingTest/ScriptHostTestHelper.cs
+++ b/tests/HostingTest/ScriptHostTestHelper.cs
@@ -99,6 +99,7 @@ namespace HostingTest
            return new ScriptRuntime(CreateScriptRuntimeSetup(path));
        }
 
+#if FEATURE_REMOTING
        private ScriptRuntime CreateRemoteAppDomain(string/*!*/ testPath) {
            AppDomain newAppDomain;
            ScriptRuntime newScriptRuntime;
@@ -106,6 +107,7 @@ namespace HostingTest
            newScriptRuntime = ScriptRuntime.CreateRemote(newAppDomain, CreateScriptRuntimeSetup(testPath));
            return newScriptRuntime;
        }
+#endif
 
        /// <summary>
        /// ValidateProperties associated with Host -- compare test and expected PAL value(s)

--- a/tests/HostingTest/ScriptRuntimeSetupTest.cs
+++ b/tests/HostingTest/ScriptRuntimeSetupTest.cs
@@ -167,8 +167,10 @@ namespace HostingTest {
             string configFile = GetTempConfigFile(new[] { lang});
             var srs = ScriptRuntimeSetup.ReadConfiguration(configFile);
 
-            //this should throw..error message should be meaningful
+            // This should throw; error message should be meaningful - PublicKeyToken contains non-hex chars
             var sr = new ScriptRuntime(srs);
+            // On Mono, the exception is thrown when trying to load the assembly, not when creating the runtime
+            var eng = sr.GetEngine("sn");
             Assert.Fail("some exception should have been thrown");
         }
 

--- a/tests/HostingTest/ScriptRuntimeTest.cs
+++ b/tests/HostingTest/ScriptRuntimeTest.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+#if FEATURE_REMOTING
 using System.Security;
 using System.Security.Policy;
+#endif
 using System.Text;
 using IronPython.Runtime;
 using Microsoft.Scripting;
@@ -15,6 +17,7 @@ namespace HostingTest{
     [TestFixture]
     public partial class ScriptRuntimeTest : HAPITestBase
     {
+#if FEATURE_REMOTING
         [Test]
         public void Create_WithCurrentAppDomain(){
             ScriptRuntime currentSR = CreateRemoteRuntime(AppDomain.CurrentDomain);
@@ -94,6 +97,7 @@ namespace HostingTest{
         }
 
         [Test]
+        [Platform(Exclude="Mono", Reason="No CAS on Mono.")]
         public void Create_PartialTrust() {
             // basic check of running a host in partial trust
             AppDomainSetup info = new AppDomainSetup();
@@ -113,6 +117,7 @@ namespace HostingTest{
 
             AppDomain.Unload(newDomain);
         }
+#endif
         
         [Test]
         [Negative]
@@ -179,6 +184,7 @@ namespace HostingTest{
             Assert.Inconclusive("Test not yet implemented");
         }
 
+#if FEATURE_REMOTING
         [ExpectedException(typeof(SyntaxErrorException))]
         [Test]//regression test for DDB 488971
         public void ExecuteFile_RemoteADAndSyntaxError() {
@@ -189,6 +195,7 @@ namespace HostingTest{
 
             runtime.ExecuteFile(tmpFile); //throws 'SourceUnit not serializable exception'
         }
+#endif
 
 
         [Test]

--- a/tests/HostingTest/ScriptRuntimeTestHelper.cs
+++ b/tests/HostingTest/ScriptRuntimeTestHelper.cs
@@ -24,9 +24,11 @@ namespace HostingTest
             }
         }
 
+#if FEATURE_REMOTING
         internal static ScriptRuntime CreateRuntime(AppDomain appDomain) {
             return ScriptRuntime.CreateRemote(appDomain, CreateSetup());
         }
+#endif
 
         internal static ScriptRuntime CreatePythonOnlyRuntime(string[] ids, string[] exts) {
             ScriptRuntimeSetup srs = new ScriptRuntimeSetup();

--- a/tests/HostingTest/ScriptScopeTest.cs
+++ b/tests/HostingTest/ScriptScopeTest.cs
@@ -529,6 +529,7 @@ namespace HostingTest {
         ///    return of false
         /// 
         /// </summary>
+#if FEATURE_REMOTING
         [Test]
         public void TryGetVariableAsHandle_MultipleCases() {
 
@@ -557,6 +558,7 @@ namespace HostingTest {
             Assert.IsNull(objHVal);
 
         }
+#endif
 
         /// <summary>
         /// Name that exists, T value requiring no conversion for
@@ -604,6 +606,7 @@ namespace HostingTest {
         }
 
         //regression test for DDB:488990
+#if FEATURE_REMOTING
         [Test]
         public void GetItems_RemoteAD() {
             ScriptScope scope = _remoteRuntime.CreateScope();
@@ -613,6 +616,7 @@ namespace HostingTest {
 
             TestHelpers.AreEqualCollections<KeyValuePair<string, object>>(dict, scope.GetItems());
         }
+#endif
 
         [Test]
         public void GetItems_EmptyScope() {
@@ -628,10 +632,12 @@ namespace HostingTest {
 
 
         
+#if FEATURE_REMOTING
         [Test]
         public void GetItems_MultipleCallsRemoteRuntime() {
             ValidateGetItems(_remoteRuntime);
         }
+#endif
 
         // Bug # 482429 validation
         [Test]
@@ -686,6 +692,7 @@ namespace HostingTest {
 
 
 
+#if FEATURE_REMOTING
         /// <summary>
         /// Verify that that null name will throw exception
         /// </summary>
@@ -768,6 +775,7 @@ namespace HostingTest {
             Assert.AreEqual(2, two);
 
         }
+#endif
 
 
 

--- a/tests/HostingTest/TestHelpers.cs
+++ b/tests/HostingTest/TestHelpers.cs
@@ -181,6 +181,7 @@ namespace HostingTest {
         }
 
 
+#if FEATURE_REMOTING
         public static AppDomain CreateAppDomain(string name) {
             var setup = new AppDomainSetup {
                 ApplicationBase = BinDirectory,
@@ -189,6 +190,7 @@ namespace HostingTest {
             };
             return AppDomain.CreateDomain(name, null, setup);
         }
+#endif
 
         public class EnvSetupTearDown {
             string _envName;


### PR DESCRIPTION
On .NET(all versions) this means that remoting tests are not compiled — the API is not available. I used the feature compilation symbol like in core DLR, hence the new `Directory.Build.props`.

On Mono, CAS compiles but is not supported. Surprisingly, remoting works.