### PR TITLE
Refactor ToReadOnlyCollection in Microsoft.Dynamic

### DIFF
--- a/src/core/Microsoft.Dynamic/Ast/GeneratorExpression.cs
+++ b/src/core/Microsoft.Dynamic/Ast/GeneratorExpression.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Scripting.Ast {
             ContractUtils.Requires(delegateType.IsSubclassOf(typeof(MulticastDelegate)), "Lambda type parameter must be derived from System.Delegate");
             Type generatorType = delegateType.GetMethod("Invoke").GetReturnType();
 
-            var paramList = parameters.ToReadOnly();
+            var paramList = parameters.ToReadOnlyCollection();
             if (IsEnumerableType(generatorType)) {
                 // rewrite body
                 body = TransformEnumerable(body, paramList);

--- a/src/core/Microsoft.Dynamic/Ast/LightDynamicExpression.cs
+++ b/src/core/Microsoft.Dynamic/Ast/LightDynamicExpression.cs
@@ -509,7 +509,7 @@ namespace Microsoft.Scripting.Ast {
 
         public override Expression Reduce() {
             Debug.Assert(_args.Count > 0);
-            return DynamicExpression.Dynamic(Binder, Type, _args.ToReadOnly());
+            return DynamicExpression.Dynamic(Binder, Type, _args.ToReadOnlyCollection());
         }
 
         protected sealed override int ArgumentCount {

--- a/src/core/Microsoft.Dynamic/Ast/MethodCallExpression.cs
+++ b/src/core/Microsoft.Dynamic/Ast/MethodCallExpression.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Scripting.Ast {
             if (convertedArguments == arguments) {
                 // we didn't convert anything, just convert the users original
                 // array to a readonly collection.
-                finalArgs = convertedArguments.ToReadOnly();
+                finalArgs = convertedArguments.ToReadOnlyCollection();
             } else {
                 // we already copied the array so just stick it in a readonly collection.
                 finalArgs = new ReadOnlyCollection<Expression>(convertedArguments);

--- a/src/core/Microsoft.Dynamic/Ast/NewArrayExpression.cs
+++ b/src/core/Microsoft.Dynamic/Ast/NewArrayExpression.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Scripting.Ast {
                 throw new ArgumentException("Argument type cannot be System.Void.");
             }
 
-            ReadOnlyCollection<Expression> initializerList = initializers.ToReadOnly();
+            ReadOnlyCollection<Expression> initializerList = initializers.ToReadOnlyCollection();
 
             Expression[] clone = null;
             for (int i = 0; i < initializerList.Count; i++) {

--- a/src/core/Microsoft.Dynamic/Runtime/BinderOps.cs
+++ b/src/core/Microsoft.Dynamic/Runtime/BinderOps.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -50,7 +51,7 @@ namespace Microsoft.Scripting.Runtime {
 
         public static IReadOnlyDictionary<TKey, TValue> MakeReadOnlyDictionary<TKey, TValue>(string[] names, object[] values) {
             if (names.Length == 0) {
-                return EmptyReadOnlyDictionary<TKey, TValue>.Instance;
+                return ReadOnlyDictionary<TKey, TValue>.Empty;
             }
             return MakeDictionary<TKey, TValue>(names, values);
         }

--- a/src/core/Microsoft.Dynamic/Utils/CollectionExtensions.cs
+++ b/src/core/Microsoft.Dynamic/Utils/CollectionExtensions.cs
@@ -6,39 +6,32 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Scripting.Utils {
     internal static class CollectionExtensions {
         /// <summary>
-        /// Wraps the provided enumerable into a ReadOnlyCollection{T}
-        /// 
-        /// Copies all of the data into a new array, so the data can't be
-        /// changed after creation. The exception is if the enumerable is
-        /// already a ReadOnlyCollection{T}, in which case we just return it.
+        /// Materlializes the provided enumerable if needed and wraps it in a ReadOnlyCollection{T}
         /// </summary>
-        internal static ReadOnlyCollection<T> ToReadOnly<T>(this IEnumerable<T> enumerable) {
-            if (enumerable is null) {
-                return EmptyReadOnlyCollection<T>.Instance;
-            }
-
-            if (enumerable is ReadOnlyCollection<T> roCollection) {
-                return roCollection;
-            }
-
-            if (enumerable is ICollection<T> collection) {
-                int count = collection.Count;
-                if (count == 0) {
-                    return EmptyReadOnlyCollection<T>.Instance;
-                }
-
-                T[] array = new T[count];
-                collection.CopyTo(array, 0);
-                return new ReadOnlyCollection<T>(array);
-            }
-
-            // ToArray trims the excess space and speeds up access
-            return new ReadOnlyCollection<T>(new List<T>(enumerable).ToArray());
+        /// <remarks>
+        /// Copies all of the data into a new array, so the data can't be
+        /// accidentally changed after creation. The exception is if the enumerable is
+        /// already a ReadOnlyCollection{T} (or its subclass), in which case we just return it.
+        /// </remarks>
+        internal static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> enumerable) {
+            // Copy of Microsoft.Scripting.Utils.CollectionExtensions.ToReadOnlyCollection, which is internal.
+            return enumerable switch {
+                null => ReadOnlyCollection<T>.Empty,
+                ReadOnlyCollection<T> roc => roc,
+                ReadOnlyCollectionBuilder<T> builder => builder.ToReadOnlyCollection(),
+                _ => enumerable.ToArray() switch {  // ToArray does all necessary casting, copying, and possible optimizations
+                    { Length: 0 } => ReadOnlyCollection<T>.Empty,
+                    var array => new ReadOnlyCollection<T>(array),
+                },
+            };
         }
+
 
         // We could probably improve the hashing here
         internal static int ListHashCode<T>(this IEnumerable<T> list) {
@@ -134,12 +127,23 @@ namespace Microsoft.Scripting.Utils {
             Array.Copy(array, sizeOfShiftedArray, result, 0, count);
             return result;
         }
+
+#if !NET8_0_OR_GREATER
+        // Emulates ReadOnlyCollection<T>.Empty form .NET 8.0+ with what is available in .NET Framework et al.
+        // See also Microsoft.Scripting.Utils.CollectionExtensions
+        extension<T>(ReadOnlyCollection<T>) {
+            internal static ReadOnlyCollection<T> Empty => EmptyReadOnlyCollection<T>.Instance;
+        }
+
+        // CS9282: Extension declarations can include only methods or properties
+        // so a readonly field must be in a separate static class.
+        private static class EmptyReadOnlyCollection<T> {
+            internal static readonly ReadOnlyCollection<T> Instance = new(Array.Empty<T>());
+        }
+#endif
+
     }
 
-
-    internal static class EmptyReadOnlyCollection<T> {
-        internal static readonly ReadOnlyCollection<T> Instance = new(Array.Empty<T>());
-    }
 
     internal static class EmptyReadOnlyDictionary<TKey, TValue> {
         internal static readonly IReadOnlyDictionary<TKey, TValue> Instance

--- a/src/core/Microsoft.Dynamic/Utils/CollectionExtensions.cs
+++ b/src/core/Microsoft.Dynamic/Utils/CollectionExtensions.cs
@@ -130,27 +130,23 @@ namespace Microsoft.Scripting.Utils {
 
 #if !NET8_0_OR_GREATER
         // Emulates ReadOnlyCollection<T>.Empty form .NET 8.0+ with what is available in .NET Framework et al.
-        // See also Microsoft.Scripting.Utils.CollectionExtensions
+        // See also polyfill in Microsoft.Scripting.Utils.CollectionExtensions
         extension<T>(ReadOnlyCollection<T>) {
             internal static ReadOnlyCollection<T> Empty => EmptyReadOnlyCollection<T>.Instance;
         }
 
-        // CS9282: Extension declarations can include only methods or properties
-        // so a readonly field must be in a separate static class.
         private static class EmptyReadOnlyCollection<T> {
             internal static readonly ReadOnlyCollection<T> Instance = new(Array.Empty<T>());
         }
-#endif
 
-    }
+        // Emulates ReadOnlyDictionary<TKey,TValue>.Empty from .NET 8.0+ with what is available in .NET Framework et al.
+        extension<TKey, TValue>(ReadOnlyDictionary<TKey, TValue>) {
+            internal static ReadOnlyDictionary<TKey, TValue> Empty => EmptyReadOnlyDictionary<TKey, TValue>.Instance;
+        }
 
-
-    internal static class EmptyReadOnlyDictionary<TKey, TValue> {
-        internal static readonly IReadOnlyDictionary<TKey, TValue> Instance
-#if NETCOREAPP
-            = System.Collections.Immutable.ImmutableDictionary.Create<TKey, TValue>();
-#else
-            = new ReadOnlyDictionary<TKey, TValue>(new Dictionary<TKey, TValue>());
+        private static class EmptyReadOnlyDictionary<TKey, TValue> {
+            internal static readonly ReadOnlyDictionary<TKey, TValue> Instance = new(new Dictionary<TKey, TValue>());
+        }
 #endif
     }
 


### PR DESCRIPTION
This is mostly a copy of the implementation from `Microsoft.Scripting` (#340), which is `internal`. It eliminates double array allocation.

The replacement of `EmptyReadOnlyDictionary.Instance` with `ReadOnlyDictionary.Empty` follows the same pattern as for `ReadOnlyCollection.Empty`. It is used only in one place.