### PR TITLE
Simplify ToArray() in Microsoft.Dynamic

### DIFF
--- a/src/core/Microsoft.Dynamic/Actions/DefaultBinder.Operations.cs
+++ b/src/core/Microsoft.Dynamic/Actions/DefaultBinder.Operations.cs
@@ -551,7 +551,7 @@ namespace Microsoft.Scripting.Actions {
                 }
             }
 
-            return new List<MethodInfo>(dict.Values).ToArray();
+            return dict.Values.ToArray();
         }
 
         #endregion

--- a/src/core/Microsoft.Dynamic/Interpreter/InterpretedFrame.cs
+++ b/src/core/Microsoft.Dynamic/Interpreter/InterpretedFrame.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 
 using Microsoft.Scripting.Utils;
 using Microsoft.Scripting.Runtime;
+using System.Linq;
 
 namespace Microsoft.Scripting.Interpreter {
     using InterpretedFrameThreadLocal = Microsoft.Scripting.Utils.ThreadLocal<InterpretedFrame>;
@@ -145,7 +146,7 @@ namespace Microsoft.Scripting.Interpreter {
 
         internal void SaveTraceToException(Exception exception) {
             if (exception.GetData(typeof(InterpretedFrameInfo)) is null) {
-                exception.SetData(typeof(InterpretedFrameInfo), new List<InterpretedFrameInfo>(GetStackTraceDebugInfo()).ToArray());
+                exception.SetData(typeof(InterpretedFrameInfo), GetStackTraceDebugInfo().ToArray());
             }
         }
 


### PR DESCRIPTION
I think this is the last one that avoids an intermediate array object.