### PR TITLE
Use Meziantou.Polyfill

### DIFF
--- a/src/core/Microsoft.Dynamic/Microsoft.Dynamic.csproj
+++ b/src/core/Microsoft.Dynamic/Microsoft.Dynamic.csproj
@@ -6,6 +6,10 @@
     <BaseAddress>859832320</BaseAddress>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
+    <MeziantouPolyfill_IncludedPolyfills>
+      None
+    </MeziantouPolyfill_IncludedPolyfills>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0' ">
@@ -22,6 +26,13 @@
     <Reference Include="System.Configuration" Condition=" $(Features.Contains('FEATURE_CONFIGURATION')) " />
     <Reference Include="System.Runtime.Remoting" Condition=" $(Features.Contains('FEATURE_REMOTING')) " />
     <Reference Include="System.Xaml" Condition=" $(Features.Contains('FEATURE_WPF')) " />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Meziantou.Polyfill" Version="1.0.116">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/core/Microsoft.Scripting.Metadata/Microsoft.Scripting.Metadata.csproj
+++ b/src/core/Microsoft.Scripting.Metadata/Microsoft.Scripting.Metadata.csproj
@@ -6,10 +6,21 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);CCI</DefineConstants>
+    <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
+    <MeziantouPolyfill_IncludedPolyfills>
+      None
+    </MeziantouPolyfill_IncludedPolyfills>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Scripting\Microsoft.Scripting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Meziantou.Polyfill" Version="1.0.116">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <Import Project="$(AfterTargetFiles)" />

--- a/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
+++ b/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
@@ -4,10 +4,21 @@
     <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <BaseAddress>857735168</BaseAddress>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
+    <MeziantouPolyfill_IncludedPolyfills>
+      None
+    </MeziantouPolyfill_IncludedPolyfills>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(IsFullFramework)' == 'true' ">
     <Reference Include="System.Configuration" Condition=" $(Features.Contains('FEATURE_CONFIGURATION')) " />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Meziantou.Polyfill" Version="1.0.116">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
By default, _Meizantou.Polyfill_ generates everything that it can that is missing on the target framework, regardless whether it is being used or not. It also not being trimmed away during linking. This is the same as _PolySharp_, but because _Meizantou.Polyfill_ contains much more polyfills, it is significantly more generated code. By my estimates on `net462`, it is ca. ~100K vs. 10K for _PolyFill_. This may be OK for tests, but I regard it as excessive for the production DLLs.

A way to avoid it is to define an allow-list. Features (types, properties, etc.) that are needed and used are listed in the `.csproj` file, others are not generated.

This PR contains only the reference to _Meizantou.Polyfill_ with no polyfils included. I set it up this way so I can work on several things in parallel that depend on polyfills. Even then, on `net462` there are some (empty) types generated, which takes ca. 1K. I think it may be a deficiency in the library that can be remedied, and I may open an issue there, or even submit a PR, if I have time.

Of course all this size increase issues are only relevant on older targets that are missing the newer types; on .NET 10 nothing is being generated so there is no size increase beyond that 1K.