### PR TITLE
Enable nullable annotations in basic types in Scripting

### DIFF
--- a/src/core/Microsoft.Scripting/ArgumentTypeException.cs
+++ b/src/core/Microsoft.Scripting/ArgumentTypeException.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Runtime.Serialization;
 
@@ -12,11 +14,11 @@ namespace Microsoft.Scripting {
             : base() {
         }
 
-        public ArgumentTypeException(string message)
+        public ArgumentTypeException(string? message)
             : base(message) {
         }
 
-        public ArgumentTypeException(string message, Exception innerException)
+        public ArgumentTypeException(string? message, Exception? innerException)
             : base(message, innerException) {
         }
 

--- a/src/core/Microsoft.Scripting/AssemblyLoadedEventArgs.cs
+++ b/src/core/Microsoft.Scripting/AssemblyLoadedEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/core/Microsoft.Scripting/CompilerOptions.cs
+++ b/src/core/Microsoft.Scripting/CompilerOptions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/Hosting/MemberKind.cs
+++ b/src/core/Microsoft.Scripting/Hosting/MemberKind.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.Scripting.Hosting {
     /// <summary>
     /// Specifies the type of member.

--- a/src/core/Microsoft.Scripting/Hosting/ParameterFlags.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ParameterFlags.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Scripting.Hosting {

--- a/src/core/Microsoft.Scripting/IndexSpan.cs
+++ b/src/core/Microsoft.Scripting/IndexSpan.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 using Microsoft.Scripting.Utils;
@@ -33,7 +35,7 @@ namespace Microsoft.Scripting {
             return Length.GetHashCode() ^ Start.GetHashCode();
         }
 
-        public override bool Equals(object obj) =>
+        public override bool Equals(object? obj) =>
             obj is IndexSpan span && Equals(span);
 
         public static bool operator ==(IndexSpan self, IndexSpan other) => self.Equals(other);

--- a/src/core/Microsoft.Scripting/InvalidImplementationException.cs
+++ b/src/core/Microsoft.Scripting/InvalidImplementationException.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Runtime.Serialization;
 
@@ -12,11 +14,11 @@ namespace Microsoft.Scripting {
             : base() {
         }
 
-        public InvalidImplementationException(string message)
+        public InvalidImplementationException(string? message)
             : base(message) {
         }
 
-        public InvalidImplementationException(string message, Exception e)
+        public InvalidImplementationException(string? message, Exception? e)
             : base(message, e) {
         }
 

--- a/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
+++ b/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
@@ -6,6 +6,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <MeziantouPolyfill_IncludedPolyfills>
+      T:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute;
+      T:System.Diagnostics.CodeAnalysis.NotNullAttribute;
       P:System.Collections.ObjectModel.ReadOnlyCollection`1.Empty;
     </MeziantouPolyfill_IncludedPolyfills>
   </PropertyGroup>

--- a/src/core/Microsoft.Scripting/PlatformAdaptationLayer.cs
+++ b/src/core/Microsoft.Scripting/PlatformAdaptationLayer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -195,19 +197,19 @@ namespace Microsoft.Scripting {
             return Path.Combine(path1, path2);
         }
 
-        public virtual string GetFileName(string path) {
+        public virtual string? GetFileName(string? path) {
             return Path.GetFileName(path);
         }
 
-        public virtual string GetDirectoryName(string path) {
+        public virtual string? GetDirectoryName(string? path) {
             return Path.GetDirectoryName(path);
         }
 
-        public virtual string GetExtension(string path) {
+        public virtual string? GetExtension(string? path) {
             return Path.GetExtension(path);
         }
 
-        public virtual string GetFileNameWithoutExtension(string path) {
+        public virtual string? GetFileNameWithoutExtension(string? path) {
             return Path.GetFileNameWithoutExtension(path);
         }
 
@@ -222,8 +224,8 @@ namespace Microsoft.Scripting {
             if (IsSingleRootFileSystem) {
                 return Path.IsPathRooted(path);
             }
-            var root = Path.GetPathRoot(path);
-            return root.EndsWith(@":\", StringComparison.Ordinal) || root.EndsWith(@":/", StringComparison.Ordinal);
+            string? root = Path.GetPathRoot(path);
+            return root is not null && (root.EndsWith(@":\", StringComparison.Ordinal) || root.EndsWith(@":/", StringComparison.Ordinal));
 #else
             throw new NotImplementedException();
 #endif
@@ -274,7 +276,7 @@ namespace Microsoft.Scripting {
 
         #region Environmental Variables
 
-        public virtual string GetEnvironmentVariable(string key) {
+        public virtual string? GetEnvironmentVariable(string key) {
 #if FEATURE_PROCESS
             return Environment.GetEnvironmentVariable(key);
 #else
@@ -283,7 +285,7 @@ namespace Microsoft.Scripting {
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2201:DoNotRaiseReservedExceptionTypes")]
-        public virtual void SetEnvironmentVariable(string key, string value) {
+        public virtual void SetEnvironmentVariable(string key, string? value) {
 #if FEATURE_PROCESS
             if (value is not null && value.Length == 0) {
                 SetEmptyEnvironmentVariable(key);
@@ -316,7 +318,7 @@ namespace Microsoft.Scripting {
 
             foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
             {
-                result.Add((string)entry.Key, (string)entry.Value);
+                result.Add((string)entry.Key, (entry.Value is string value) ? value : string.Empty);
             }
 
             return result;

--- a/src/core/Microsoft.Scripting/Properties/AssemblyInfo.cs
+++ b/src/core/Microsoft.Scripting/Properties/AssemblyInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/core/Microsoft.Scripting/Runtime/DynamicStackFrame.cs
+++ b/src/core/Microsoft.Scripting/Runtime/DynamicStackFrame.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Reflection;
 
@@ -11,12 +13,12 @@ namespace Microsoft.Scripting.Runtime {
     /// </summary>
     [Serializable]
     public class DynamicStackFrame {
-        private readonly string _funcName;
-        private readonly string _filename;
+        private readonly string? _funcName;
+        private readonly string? _filename;
         private readonly int _lineNo;
-        private readonly MethodBase _method;
+        private readonly MethodBase? _method;
 
-        public DynamicStackFrame(MethodBase method, string funcName, string filename, int line) {
+        public DynamicStackFrame(MethodBase? method, string? funcName, string? filename, int line) {
             _funcName = funcName;
             _filename = filename;
             _lineNo = line;
@@ -24,17 +26,17 @@ namespace Microsoft.Scripting.Runtime {
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        public MethodBase GetMethod() {
+        public MethodBase? GetMethod() {
             return _method;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        public string GetMethodName() {
+        public string? GetMethodName() {
             return _funcName;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        public string GetFileName() {
+        public string? GetFileName() {
             return _filename;
         }
 

--- a/src/core/Microsoft.Scripting/Runtime/NotNullAttribute.cs
+++ b/src/core/Microsoft.Scripting/Runtime/NotNullAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Scripting.Runtime {

--- a/src/core/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
+++ b/src/core/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/Runtime/StreamContentProvider.cs
+++ b/src/core/Microsoft.Scripting/Runtime/StreamContentProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.IO;
 

--- a/src/core/Microsoft.Scripting/Runtime/TokenTriggers.cs
+++ b/src/core/Microsoft.Scripting/Runtime/TokenTriggers.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/ScriptCodeParseResult.cs
+++ b/src/core/Microsoft.Scripting/ScriptCodeParseResult.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.Scripting {
     public enum ScriptCodeParseResult {
         /// <summary>

--- a/src/core/Microsoft.Scripting/Severity.cs
+++ b/src/core/Microsoft.Scripting/Severity.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.Scripting {
     public enum Severity {
         Ignore,

--- a/src/core/Microsoft.Scripting/SourceCodeKind.cs
+++ b/src/core/Microsoft.Scripting/SourceCodeKind.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.ComponentModel;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/SourceLocation.cs
+++ b/src/core/Microsoft.Scripting/SourceLocation.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 
@@ -156,7 +158,7 @@ namespace Microsoft.Scripting {
         public bool Equals(SourceLocation other) =>
             other.Index == Index && other.Line == Line && other.Column == Column;
 
-        public override bool Equals(object obj) =>
+        public override bool Equals(object? obj) =>
             obj is SourceLocation other && Equals(other);
 
         public override int GetHashCode() {

--- a/src/core/Microsoft.Scripting/TokenCategory.cs
+++ b/src/core/Microsoft.Scripting/TokenCategory.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.Scripting {
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1027:MarkEnumsWithFlags")]

--- a/src/core/Microsoft.Scripting/Utils/ArrayUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ArrayUtils.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -21,7 +23,12 @@ namespace Microsoft.Scripting.Utils {
                 _comparison = comparison;
             }
 
-            public int Compare(T x, T y) {
+            public int Compare(T? x, T? y) {
+                if (x is null) {
+                    return (y is null) ? 0 : -1;
+                } else if (y is null) {
+                    return 1;
+                }
                 return _comparison(x, y);
             }
         }
@@ -68,7 +75,7 @@ namespace Microsoft.Scripting.Utils {
             return res;
         }
 
-        public static T[] MakeArray<T>(ICollection<T> elements, int reservedSlotsBefore, int reservedSlotsAfter) {
+        public static T[] MakeArray<T>(ICollection<T>? elements, int reservedSlotsBefore, int reservedSlotsAfter) {
             if (reservedSlotsAfter < 0) throw new ArgumentOutOfRangeException(nameof(reservedSlotsAfter));
             if (reservedSlotsBefore < 0) throw new ArgumentOutOfRangeException(nameof(reservedSlotsBefore));
 
@@ -192,7 +199,7 @@ namespace Microsoft.Scripting.Utils {
         }
 
         public static void SwapLastTwo<T>(T[] array) {
-            Debug.Assert(array is not null && array.Length >= 2);
+            Debug.Assert(array.Length >= 2);
 
             T temp = array[array.Length - 1];
             array[array.Length - 1] = array[array.Length - 2];

--- a/src/core/Microsoft.Scripting/Utils/Assert.cs
+++ b/src/core/Microsoft.Scripting/Utils/Assert.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #define DEBUG
 
 using System;
@@ -11,30 +13,30 @@ using System.Diagnostics;
 namespace Microsoft.Scripting.Utils {
     internal static class Assert {
         [Conditional("DEBUG")]
-        public static void NotNull(object var) {
+        public static void NotNull(object? var) {
             Debug.Assert(var is not null);
         }
 
         [Conditional("DEBUG")]
-        public static void NotNull(object var1, object var2) {
+        public static void NotNull(object? var1, object? var2) {
             Debug.Assert(var1 is not null && var2 is not null);
         }
 
         [Conditional("DEBUG")]
-        public static void NotNull(object var1, object var2, object var3) {
+        public static void NotNull(object? var1, object? var2, object? var3) {
             Debug.Assert(var1 is not null && var2 is not null && var3 is not null);
         }
 
         [Conditional("DEBUG")]
-        public static void NotNullItems<T>(IEnumerable<T> items) where T : class {
+        public static void NotNullItems<T>(IEnumerable<T>? items) where T : class {
             Debug.Assert(items is not null);
-            foreach (object item in items) {
+            foreach (object item in items!) {
                 Debug.Assert(item is not null);
             }
         }
 
         [Conditional("DEBUG")]
-        public static void NotEmpty(string str) {
+        public static void NotEmpty(string? str) {
             Debug.Assert(!String.IsNullOrEmpty(str));
         }
     }

--- a/src/core/Microsoft.Scripting/Utils/CollectionExtensions.cs
+++ b/src/core/Microsoft.Scripting/Utils/CollectionExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -21,7 +23,7 @@ namespace Microsoft.Scripting.Utils {
         /// already a ReadOnlyCollection{T} (or its subclass), in which case we just return it.
         /// </remarks>
         /// <seealso href="https://github.com/dotnet/runtime/blob/b70c35ed8a2e7ae0d91de76f4f5d26c2e7d2c6cd/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs#L58"/>
-        internal static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> enumerable) {
+        internal static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T>? enumerable) {
             return enumerable switch {
                 null => ReadOnlyCollection<T>.Empty,
                 ReadOnlyCollection<T> roc => roc,

--- a/src/core/Microsoft.Scripting/Utils/ConsoleInputStream.cs
+++ b/src/core/Microsoft.Scripting/Utils/ConsoleInputStream.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/core/Microsoft.Scripting/Utils/ConsoleStreamType.cs
+++ b/src/core/Microsoft.Scripting/Utils/ConsoleStreamType.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.Scripting.Utils {
     public enum ConsoleStreamType {
         Input,

--- a/src/core/Microsoft.Scripting/Utils/ContractUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ContractUtils.cs
@@ -2,14 +2,17 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Scripting.Utils {
     internal static class ContractUtils {
-        public static void RequiresNotNull(object value, string paramName) {
+        public static void RequiresNotNull([NotNull] object? value, string paramName) {
             Assert.NotEmpty(paramName);
 
             if (value is null) {
@@ -39,14 +42,14 @@ namespace Microsoft.Scripting.Utils {
             }
         }
 
-        public static void RequiresNotEmpty(string str, string paramName) {
+        public static void RequiresNotEmpty([NotNull] string? str, string paramName) {
             RequiresNotNull(str, paramName);
             if (str.Length == 0) {
                 throw new ArgumentException(Strings.NonEmptyStringRequired, paramName);
             }
         }
 
-        public static void RequiresNotEmpty<T>(ICollection<T> collection, string paramName) {
+        public static void RequiresNotEmpty<T>([NotNull] ICollection<T>? collection, string paramName) {
             RequiresNotNull(collection, paramName);
             if (collection.Count == 0) {
                 throw new ArgumentException(Strings.NonEmptyCollectionRequired, paramName);
@@ -78,7 +81,7 @@ namespace Microsoft.Scripting.Utils {
         /// <summary>
         /// Requires the array and all its items to be non-null.
         /// </summary>
-        public static void RequiresNotNullItems<T>(IList<T> array, string arrayName) {
+        public static void RequiresNotNullItems<T>([NotNull] IList<T>? array, string arrayName) {
             Assert.NotNull(arrayName);
             RequiresNotNull(array, arrayName);
 
@@ -92,7 +95,7 @@ namespace Microsoft.Scripting.Utils {
         /// <summary>
         /// Requires the enumerable collection and all its items to be non-null.
         /// </summary>
-        public static void RequiresNotNullItems<T>(IEnumerable<T> collection, string collectionName) {
+        public static void RequiresNotNullItems<T>([NotNull] IEnumerable<T>? collection, string collectionName) {
             Assert.NotNull(collectionName);
             RequiresNotNull(collection, collectionName);
 

--- a/src/core/Microsoft.Scripting/Utils/DelegateUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/DelegateUtils.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if FEATURE_REFEMIT
 
 using System;
@@ -15,8 +17,8 @@ using System.Threading;
 
 namespace Microsoft.Scripting.Utils {
     internal static class DelegateUtils {
-        private static AssemblyBuilder _assembly;
-        private static ModuleBuilder _modBuilder;
+        private static AssemblyBuilder? _assembly;
+        private static ModuleBuilder? _modBuilder;
         private static int _typeCount;
         private static readonly Type[] _DelegateCtorSignature = new Type[] { typeof(object), typeof(IntPtr) };
 
@@ -39,7 +41,7 @@ namespace Microsoft.Scripting.Utils {
                 }
             }
 
-            return _modBuilder.DefineType(
+            return _modBuilder!.DefineType(
                 name + Interlocked.Increment(ref _typeCount),
                 TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass,                
                 typeof(MulticastDelegate)
@@ -64,7 +66,7 @@ namespace Microsoft.Scripting.Utils {
                 MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public,
                 CallingConventions.Standard, _DelegateCtorSignature).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
             tb.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, typeof(object), paramTypes).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
-            return tb.CreateTypeInfo();
+            return tb.CreateTypeInfo()!;
         }
     }
 }

--- a/src/core/Microsoft.Scripting/Utils/ExceptionFactory.Generated.cs
+++ b/src/core/Microsoft.Scripting/Utils/ExceptionFactory.Generated.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/Utils/ExceptionUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ExceptionUtils.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Scripting.Utils {

--- a/src/core/Microsoft.Scripting/Utils/ExpressionUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ExpressionUtils.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Linq.Expressions;
 
 using System;

--- a/src/core/Microsoft.Scripting/Utils/NativeMethods.cs
+++ b/src/core/Microsoft.Scripting/Utils/NativeMethods.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if FEATURE_NATIVE
 
 using System;
@@ -11,7 +13,7 @@ namespace Microsoft.Scripting.Utils {
     internal static class NativeMethods {
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError=true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool SetEnvironmentVariable(string name, string value);
+        internal static extern bool SetEnvironmentVariable(string name, string? value);
     }
 }
 

--- a/src/core/Microsoft.Scripting/Utils/ReflectionUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ReflectionUtils.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Reflection;

--- a/src/core/Microsoft.Scripting/Utils/TextStream.cs
+++ b/src/core/Microsoft.Scripting/Utils/TextStream.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 
@@ -15,18 +18,20 @@ namespace Microsoft.Scripting.Utils {
             _buffered = buffered;
         }
 
-        public abstract Encoding  Encoding { get; }
-        public abstract TextReader Reader { get; }
-        public abstract TextWriter Writer { get; }
+        public abstract Encoding Encoding { get; }
+        public abstract TextReader? Reader { get; }
+        public abstract TextWriter? Writer { get; }
 
         public sealed override bool CanSeek {
             get { return false; }
         }
 
+        [MemberNotNullWhen(true, nameof(Writer))]
         public sealed override bool CanWrite {
             get { return Writer is not null; }
         }
 
+        [MemberNotNullWhen(true, nameof(Reader))]
         public sealed override bool CanRead {
             get { return Reader is not null; }
         }
@@ -36,7 +41,7 @@ namespace Microsoft.Scripting.Utils {
             Writer.Flush();
         }
 
-        public sealed override int Read(byte[]  buffer, int offset, int count) {
+        public sealed override int Read(byte[] buffer, int offset, int count) {
             if (!CanRead) throw new InvalidOperationException();
             ContractUtils.RequiresArrayRange(buffer, offset, count, "offset", "count");
 
@@ -45,7 +50,8 @@ namespace Microsoft.Scripting.Utils {
             return Encoding.GetBytes(charBuffer, 0, realCount, buffer, offset);
         }
 
-        public sealed override void Write(byte[]  buffer, int offset, int count) {
+        public sealed override void Write(byte[] buffer, int offset, int count) {
+            if (!CanWrite) throw new InvalidOperationException();
             ContractUtils.RequiresArrayRange(buffer, offset, count, "offset", "count");
             char[] charBuffer = Encoding.GetChars(buffer, offset, count);
             Writer.Write(charBuffer, 0, charBuffer.Length);
@@ -82,19 +88,19 @@ namespace Microsoft.Scripting.Utils {
 
     internal sealed class TextStream : TextStreamBase {
 
-        private readonly TextReader _reader;
-        private readonly TextWriter _writer;
-        private readonly Encoding  _encoding;
+        private readonly TextReader? _reader;
+        private readonly TextWriter? _writer;
+        private readonly Encoding _encoding;
 
         public override Encoding Encoding {
             get { return _encoding; }
         }
 
-        public override TextReader Reader {
+        public override TextReader? Reader {
             get { return _reader; }
         }
 
-        public override TextWriter Writer {
+        public override TextWriter? Writer {
             get { return _writer; }
         }
 


### PR DESCRIPTION
Activates creation of polyfills `NotNull` and  `MemberNotNullWhen`.