### PR TITLE
Upgrade to use Meziantou.Polyfill 1.0.120

### DIFF
--- a/src/core/Microsoft.Dynamic/Microsoft.Dynamic.csproj
+++ b/src/core/Microsoft.Dynamic/Microsoft.Dynamic.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Polyfill" Version="1.0.116">
+    <PackageReference Include="Meziantou.Polyfill" Version="1.0.120">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/core/Microsoft.Scripting.Metadata/Microsoft.Scripting.Metadata.csproj
+++ b/src/core/Microsoft.Scripting.Metadata/Microsoft.Scripting.Metadata.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Polyfill" Version="1.0.116">
+    <PackageReference Include="Meziantou.Polyfill" Version="1.0.120">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
+++ b/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Polyfill" Version="1.0.116">
+    <PackageReference Include="Meziantou.Polyfill" Version="1.0.120">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This version is more frugal with generation on targets that already have the requested polyfills, like `net10.0`.