### PR TITLE
Remove nullable annotations directives from Scripting

### DIFF
--- a/src/core/Microsoft.Scripting/ArgumentTypeException.cs
+++ b/src/core/Microsoft.Scripting/ArgumentTypeException.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Runtime.Serialization;
 

--- a/src/core/Microsoft.Scripting/AssemblyLoadedEventArgs.cs
+++ b/src/core/Microsoft.Scripting/AssemblyLoadedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/core/Microsoft.Scripting/CompilerOptions.cs
+++ b/src/core/Microsoft.Scripting/CompilerOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/ErrorSink.cs
+++ b/src/core/Microsoft.Scripting/ErrorSink.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Threading;
 using Microsoft.Scripting.Utils;
 

--- a/src/core/Microsoft.Scripting/Hosting/CompiledCode.cs
+++ b/src/core/Microsoft.Scripting/Hosting/CompiledCode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/Configuration/LanguageElement.cs
+++ b/src/core/Microsoft.Scripting/Hosting/Configuration/LanguageElement.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_CONFIGURATION
 
 using System;

--- a/src/core/Microsoft.Scripting/Hosting/Configuration/LanguageElementCollection.cs
+++ b/src/core/Microsoft.Scripting/Hosting/Configuration/LanguageElementCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_CONFIGURATION
 
 using System.Configuration;

--- a/src/core/Microsoft.Scripting/Hosting/Configuration/OptionElement.cs
+++ b/src/core/Microsoft.Scripting/Hosting/Configuration/OptionElement.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_CONFIGURATION
 
 using System;

--- a/src/core/Microsoft.Scripting/Hosting/Configuration/OptionElementCollection.cs
+++ b/src/core/Microsoft.Scripting/Hosting/Configuration/OptionElementCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_CONFIGURATION
 
 using System.Configuration;

--- a/src/core/Microsoft.Scripting/Hosting/Configuration/Section.cs
+++ b/src/core/Microsoft.Scripting/Hosting/Configuration/Section.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_CONFIGURATION
 
 using System;

--- a/src/core/Microsoft.Scripting/Hosting/DocumentationOperations.cs
+++ b/src/core/Microsoft.Scripting/Hosting/DocumentationOperations.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/ErrorListener.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ErrorListener.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 #if FEATURE_REMOTING

--- a/src/core/Microsoft.Scripting/Hosting/ErrorListenerProxy.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ErrorListenerProxy.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace Microsoft.Scripting.Hosting {
 
     /// <summary>

--- a/src/core/Microsoft.Scripting/Hosting/ErrorSinkProxyListener.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ErrorSinkProxyListener.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace Microsoft.Scripting.Hosting {
     /// <summary>
     /// Bridges ErrorListener and ErrorSink. It provides the reverse functionality as ErrorSinkProxyListener

--- a/src/core/Microsoft.Scripting/Hosting/ExceptionOperations.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ExceptionOperations.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/core/Microsoft.Scripting/Hosting/LanguageSetup.cs
+++ b/src/core/Microsoft.Scripting/Hosting/LanguageSetup.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/core/Microsoft.Scripting/Hosting/MemberDoc.cs
+++ b/src/core/Microsoft.Scripting/Hosting/MemberDoc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 using Microsoft.Scripting.Utils;

--- a/src/core/Microsoft.Scripting/Hosting/MemberKind.cs
+++ b/src/core/Microsoft.Scripting/Hosting/MemberKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace Microsoft.Scripting.Hosting {
     /// <summary>
     /// Specifies the type of member.

--- a/src/core/Microsoft.Scripting/Hosting/ObjectOperations.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ObjectOperations.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/OverloadDoc.cs
+++ b/src/core/Microsoft.Scripting/Hosting/OverloadDoc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/core/Microsoft.Scripting/Hosting/ParameterDoc.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ParameterDoc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 using Microsoft.Scripting.Utils;

--- a/src/core/Microsoft.Scripting/Hosting/ParameterFlags.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ParameterFlags.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.Scripting.Hosting {

--- a/src/core/Microsoft.Scripting/Hosting/Providers/HostingHelpers.cs
+++ b/src/core/Microsoft.Scripting/Hosting/Providers/HostingHelpers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/ScriptEngine.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ScriptEngine.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/ScriptHost.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ScriptHost.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/ScriptHostProxy.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ScriptHostProxy.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 

--- a/src/core/Microsoft.Scripting/Hosting/ScriptIO.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ScriptIO.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/ScriptRuntime.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ScriptRuntime.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/ScriptRuntimeSetup.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ScriptRuntimeSetup.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/core/Microsoft.Scripting/Hosting/ScriptScope.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ScriptScope.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/ScriptSource.cs
+++ b/src/core/Microsoft.Scripting/Hosting/ScriptSource.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/Hosting/TokenCategorizer.cs
+++ b/src/core/Microsoft.Scripting/Hosting/TokenCategorizer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 #if FEATURE_REMOTING

--- a/src/core/Microsoft.Scripting/IndexSpan.cs
+++ b/src/core/Microsoft.Scripting/IndexSpan.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 using Microsoft.Scripting.Utils;

--- a/src/core/Microsoft.Scripting/InvalidImplementationException.cs
+++ b/src/core/Microsoft.Scripting/InvalidImplementationException.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Runtime.Serialization;
 

--- a/src/core/Microsoft.Scripting/LanguageOptions.cs
+++ b/src/core/Microsoft.Scripting/LanguageOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
+++ b/src/core/Microsoft.Scripting/Microsoft.Scripting.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
     <BaseAddress>857735168</BaseAddress>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>

--- a/src/core/Microsoft.Scripting/PlatformAdaptationLayer.cs
+++ b/src/core/Microsoft.Scripting/PlatformAdaptationLayer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/core/Microsoft.Scripting/Properties/AssemblyInfo.cs
+++ b/src/core/Microsoft.Scripting/Properties/AssemblyInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/core/Microsoft.Scripting/Runtime/ContextId.cs
+++ b/src/core/Microsoft.Scripting/Runtime/ContextId.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/core/Microsoft.Scripting/Runtime/DlrConfiguration.cs
+++ b/src/core/Microsoft.Scripting/Runtime/DlrConfiguration.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/core/Microsoft.Scripting/Runtime/DocumentationProvider.cs
+++ b/src/core/Microsoft.Scripting/Runtime/DocumentationProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 
 using Microsoft.Scripting.Hosting;

--- a/src/core/Microsoft.Scripting/Runtime/DynamicOperations.cs
+++ b/src/core/Microsoft.Scripting/Runtime/DynamicOperations.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/core/Microsoft.Scripting/Runtime/DynamicRuntimeHostingProvider.cs
+++ b/src/core/Microsoft.Scripting/Runtime/DynamicRuntimeHostingProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.Scripting.Runtime {

--- a/src/core/Microsoft.Scripting/Runtime/DynamicStackFrame.cs
+++ b/src/core/Microsoft.Scripting/Runtime/DynamicStackFrame.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Reflection;
 

--- a/src/core/Microsoft.Scripting/Runtime/InvariantContext.cs
+++ b/src/core/Microsoft.Scripting/Runtime/InvariantContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/core/Microsoft.Scripting/Runtime/LanguageBoundTextContentProvider.cs
+++ b/src/core/Microsoft.Scripting/Runtime/LanguageBoundTextContentProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.IO;
 using System.Text;
 

--- a/src/core/Microsoft.Scripting/Runtime/LanguageContext.cs
+++ b/src/core/Microsoft.Scripting/Runtime/LanguageContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/core/Microsoft.Scripting/Runtime/NotNullAttribute.cs
+++ b/src/core/Microsoft.Scripting/Runtime/NotNullAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.Scripting.Runtime {

--- a/src/core/Microsoft.Scripting/Runtime/ObjectDictionaryExpando.cs
+++ b/src/core/Microsoft.Scripting/Runtime/ObjectDictionaryExpando.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq.Expressions;

--- a/src/core/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
+++ b/src/core/Microsoft.Scripting/Runtime/ParamDictionaryAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/Runtime/ParserSink.cs
+++ b/src/core/Microsoft.Scripting/Runtime/ParserSink.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace Microsoft.Scripting.Runtime {
 
     public class ParserSink {

--- a/src/core/Microsoft.Scripting/Runtime/Scope.cs
+++ b/src/core/Microsoft.Scripting/Runtime/Scope.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Dynamic;

--- a/src/core/Microsoft.Scripting/Runtime/ScopeExtension.cs
+++ b/src/core/Microsoft.Scripting/Runtime/ScopeExtension.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using Microsoft.Scripting.Utils;
 
 namespace Microsoft.Scripting.Runtime {

--- a/src/core/Microsoft.Scripting/Runtime/ScopeStorage.cs
+++ b/src/core/Microsoft.Scripting/Runtime/ScopeStorage.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/core/Microsoft.Scripting/Runtime/ScriptCode.cs
+++ b/src/core/Microsoft.Scripting/Runtime/ScriptCode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 

--- a/src/core/Microsoft.Scripting/Runtime/ScriptDomainManager.cs
+++ b/src/core/Microsoft.Scripting/Runtime/ScriptDomainManager.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/core/Microsoft.Scripting/Runtime/SharedIO.cs
+++ b/src/core/Microsoft.Scripting/Runtime/SharedIO.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;

--- a/src/core/Microsoft.Scripting/Runtime/SourceStringContentProvider.cs
+++ b/src/core/Microsoft.Scripting/Runtime/SourceStringContentProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.IO;
 

--- a/src/core/Microsoft.Scripting/Runtime/StreamContentProvider.cs
+++ b/src/core/Microsoft.Scripting/Runtime/StreamContentProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.IO;
 

--- a/src/core/Microsoft.Scripting/Runtime/StringDictionaryExpando.cs
+++ b/src/core/Microsoft.Scripting/Runtime/StringDictionaryExpando.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/core/Microsoft.Scripting/Runtime/TokenInfo.cs
+++ b/src/core/Microsoft.Scripting/Runtime/TokenInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/Runtime/TokenTriggers.cs
+++ b/src/core/Microsoft.Scripting/Runtime/TokenTriggers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/Runtime/TokenizerService.cs
+++ b/src/core/Microsoft.Scripting/Runtime/TokenizerService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.IO;
 

--- a/src/core/Microsoft.Scripting/ScriptCodeParseResult.cs
+++ b/src/core/Microsoft.Scripting/ScriptCodeParseResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace Microsoft.Scripting {
     public enum ScriptCodeParseResult {
         /// <summary>

--- a/src/core/Microsoft.Scripting/Severity.cs
+++ b/src/core/Microsoft.Scripting/Severity.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace Microsoft.Scripting {
     public enum Severity {
         Ignore,

--- a/src/core/Microsoft.Scripting/SourceCodeKind.cs
+++ b/src/core/Microsoft.Scripting/SourceCodeKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.ComponentModel;
 
 namespace Microsoft.Scripting {

--- a/src/core/Microsoft.Scripting/SourceCodeReader.cs
+++ b/src/core/Microsoft.Scripting/SourceCodeReader.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.IO;
 using System.Text;

--- a/src/core/Microsoft.Scripting/SourceFileContentProvider.cs
+++ b/src/core/Microsoft.Scripting/SourceFileContentProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else

--- a/src/core/Microsoft.Scripting/SourceLocation.cs
+++ b/src/core/Microsoft.Scripting/SourceLocation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Globalization;
 

--- a/src/core/Microsoft.Scripting/SourceSpan.cs
+++ b/src/core/Microsoft.Scripting/SourceSpan.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Globalization;
 

--- a/src/core/Microsoft.Scripting/SourceUnit.cs
+++ b/src/core/Microsoft.Scripting/SourceUnit.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Linq.Expressions;
 
 using System;

--- a/src/core/Microsoft.Scripting/SyntaxErrorException.cs
+++ b/src/core/Microsoft.Scripting/SyntaxErrorException.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Runtime.Serialization;
 using System.Dynamic;

--- a/src/core/Microsoft.Scripting/TextContentProvider.cs
+++ b/src/core/Microsoft.Scripting/TextContentProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.IO;
 using System.Text;

--- a/src/core/Microsoft.Scripting/TokenCategory.cs
+++ b/src/core/Microsoft.Scripting/TokenCategory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace Microsoft.Scripting {
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1027:MarkEnumsWithFlags")]

--- a/src/core/Microsoft.Scripting/Utils/ArrayUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ArrayUtils.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/core/Microsoft.Scripting/Utils/AssemblyQualifiedTypeName.cs
+++ b/src/core/Microsoft.Scripting/Utils/AssemblyQualifiedTypeName.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Reflection;
 

--- a/src/core/Microsoft.Scripting/Utils/Assert.cs
+++ b/src/core/Microsoft.Scripting/Utils/Assert.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #define DEBUG
 
 using System;

--- a/src/core/Microsoft.Scripting/Utils/CollectionExtensions.cs
+++ b/src/core/Microsoft.Scripting/Utils/CollectionExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/core/Microsoft.Scripting/Utils/ConsoleInputStream.cs
+++ b/src/core/Microsoft.Scripting/Utils/ConsoleInputStream.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/core/Microsoft.Scripting/Utils/ConsoleStreamType.cs
+++ b/src/core/Microsoft.Scripting/Utils/ConsoleStreamType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace Microsoft.Scripting.Utils {
     public enum ConsoleStreamType {
         Input,

--- a/src/core/Microsoft.Scripting/Utils/ContractUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ContractUtils.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/core/Microsoft.Scripting/Utils/DelegateUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/DelegateUtils.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_REFEMIT
 
 using System;

--- a/src/core/Microsoft.Scripting/Utils/ExceptionFactory.Generated.cs
+++ b/src/core/Microsoft.Scripting/Utils/ExceptionFactory.Generated.cs
@@ -9,10 +9,11 @@ using System;
 namespace Microsoft.Scripting {
 
     internal static partial class Strings {
-        private static string FormatString(string format, params object[] args) {
+        private static string FormatString(string format, params object?[] args) {
             return string.Format(System.Globalization.CultureInfo.CurrentCulture, format, args);
         }
     }
+
 
     #region Generated Microsoft.Scripting Exception Factory
 

--- a/src/core/Microsoft.Scripting/Utils/ExceptionUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ExceptionUtils.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.Scripting.Utils {

--- a/src/core/Microsoft.Scripting/Utils/ExpressionUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ExpressionUtils.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Linq.Expressions;
 
 using System;

--- a/src/core/Microsoft.Scripting/Utils/NativeMethods.cs
+++ b/src/core/Microsoft.Scripting/Utils/NativeMethods.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #if FEATURE_NATIVE
 
 using System;

--- a/src/core/Microsoft.Scripting/Utils/ReflectionUtils.cs
+++ b/src/core/Microsoft.Scripting/Utils/ReflectionUtils.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Linq;
 using System.Reflection;

--- a/src/core/Microsoft.Scripting/Utils/TextStream.cs
+++ b/src/core/Microsoft.Scripting/Utils/TextStream.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;


### PR DESCRIPTION
Since all files in `Microsoft.Scripting` are annotated, it enables nullable annotations at the whole project level, rather than individually at the beginning of each file.

Two generated files still have directive `#nullable enable` because nullability project setting does not apply to _generated_ files. But something has to be done with them:
- one is generated and checked during tests by IronPython — this is inappropiate for the DLR repo to depend on the IronPython repo;
- the other is "self contained" but being generated by IronRuby, clearly now defunct.

Perhaps best would be to use Roslyn code generators.

There are much more such cases in `Microsoft.Dynamic`.