### PR TITLE
Exclude .lscache files from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ External.LCA_RESTRICTED/Languages/IronPython/27/Lib/lib2to3/PatternGrammar2.9.9.
 *.binlog
 *.ProjectImports.zip
 *result.xml
+*.lscache


### PR DESCRIPTION
Produced by VSCode C# extension.